### PR TITLE
feat: implement phase 5 categories and rules

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -34,12 +34,12 @@
 
 ### Categories and Rules
 
-- [ ] **CATR-01**: App ships with built-in starter categories and starter categorization rules.
-- [ ] **CATR-02**: Built-in categories include Food & Dining, Groceries, Shopping, Bills & Utilities, Rent / Housing, Transport, Travel, Healthcare, Entertainment, Education, Insurance, Taxes & Fees, Cash / ATM, Transfers, Credit Card Payment, Income, Refunds / Reimbursements, Investments / Savings, and Uncategorized.
-- [ ] **CATR-03**: User rules always override heuristic categorization.
-- [ ] **CATR-04**: User can create, rename, merge, activate, deactivate, and delete only user-created categories.
-- [ ] **CATR-05**: Built-in system categories are protected from CRUD operations.
-- [ ] **CATR-06**: Income transactions can be categorized rather than kept in one undifferentiated bucket.
+- [x] **CATR-01**: App ships with built-in starter categories and starter categorization rules.
+- [x] **CATR-02**: Built-in categories include Food & Dining, Groceries, Shopping, Bills & Utilities, Rent / Housing, Transport, Travel, Healthcare, Entertainment, Education, Insurance, Taxes & Fees, Cash / ATM, Transfers, Credit Card Payment, Income, Refunds / Reimbursements, Investments / Savings, and Uncategorized.
+- [x] **CATR-03**: User rules always override heuristic categorization.
+- [x] **CATR-04**: User can create, rename, merge, activate, deactivate, and delete only user-created categories.
+- [x] **CATR-05**: Built-in system categories are protected from CRUD operations.
+- [x] **CATR-06**: Income transactions can be categorized rather than kept in one undifferentiated bucket.
 
 ### Dashboard and Insights
 
@@ -119,12 +119,12 @@ Deferred to future releases. Tracked but not in the current roadmap for release 
 | TRAN-03 | Phase 7 | Pending |
 | TRAN-04 | Phase 4 | Pending |
 | TRAN-05 | Phase 4 | Pending |
-| CATR-01 | Phase 5 | Pending |
-| CATR-02 | Phase 5 | Pending |
-| CATR-03 | Phase 5 | Pending |
-| CATR-04 | Phase 5 | Pending |
-| CATR-05 | Phase 5 | Pending |
-| CATR-06 | Phase 5 | Pending |
+| CATR-01 | Phase 5 | Complete |
+| CATR-02 | Phase 5 | Complete |
+| CATR-03 | Phase 5 | Complete |
+| CATR-04 | Phase 5 | Complete |
+| CATR-05 | Phase 5 | Complete |
+| CATR-06 | Phase 5 | Complete |
 | DASH-01 | Phase 6 | Pending |
 | DASH-02 | Phase 6 | Pending |
 | DASH-03 | Phase 6 | Pending |
@@ -143,4 +143,4 @@ Deferred to future releases. Tracked but not in the current roadmap for release 
 
 ---
 *Requirements defined: 2026-03-27*
-*Last updated: 2026-03-27 after Phase 3 completion*
+*Last updated: 2026-03-28 after Phase 5 completion*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -137,13 +137,13 @@ Plans:
 **Requirements:** CATR-01, CATR-02, CATR-03, CATR-04, CATR-05, CATR-06
 
 **Plans:** 4 plans
-**Status:** Planned (2026-03-28)
+**Status:** Complete (2026-03-28)
 
 Plans:
-- [ ] `05-01-PLAN.md` - Create the protected taxonomy foundation, durable category ids, and safe category-management repository flows
-- [ ] `05-02-PLAN.md` - Implement the deterministic rule engine, preview-first bulk apply flows, and transaction rule-suggestion handoff
-- [ ] `05-03-PLAN.md` - Build the dual-pane Categories & Rules workspace, side-panel editors, and in-context previews
-- [ ] `05-04-PLAN.md` - Add repository, renderer, and end-to-end verification plus the formal Phase 5 handoff
+- [x] `05-01-PLAN.md` - Create the protected taxonomy foundation, durable category ids, and safe category-management repository flows
+- [x] `05-02-PLAN.md` - Implement the deterministic rule engine, preview-first bulk apply flows, and transaction rule-suggestion handoff
+- [x] `05-03-PLAN.md` - Build the dual-pane Categories & Rules workspace, side-panel editors, and in-context previews
+- [x] `05-04-PLAN.md` - Add repository, renderer, and end-to-end verification plus the formal Phase 5 handoff
 
 **Success criteria**
 1. Built-in categories and starter rules work on realistic imported data.
@@ -204,7 +204,7 @@ Plans:
 
 ## Next Step
 
-Next recommended command: `$gsd-execute-phase 5`
+Next recommended command: `$gsd-discuss-phase 6`
 
 ---
-*Last updated: 2026-03-28 after Phase 4 verification and UI polish follow-through*
+*Last updated: 2026-03-28 after Phase 5 verification*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -136,6 +136,15 @@ Plans:
 
 **Requirements:** CATR-01, CATR-02, CATR-03, CATR-04, CATR-05, CATR-06
 
+**Plans:** 4 plans
+**Status:** Planned (2026-03-28)
+
+Plans:
+- [ ] `05-01-PLAN.md` - Create the protected taxonomy foundation, durable category ids, and safe category-management repository flows
+- [ ] `05-02-PLAN.md` - Implement the deterministic rule engine, preview-first bulk apply flows, and transaction rule-suggestion handoff
+- [ ] `05-03-PLAN.md` - Build the dual-pane Categories & Rules workspace, side-panel editors, and in-context previews
+- [ ] `05-04-PLAN.md` - Add repository, renderer, and end-to-end verification plus the formal Phase 5 handoff
+
 **Success criteria**
 1. Built-in categories and starter rules work on realistic imported data.
 2. User rules override heuristics consistently.
@@ -195,7 +204,7 @@ Plans:
 
 ## Next Step
 
-Next recommended command: `$gsd-discuss-phase 5`
+Next recommended command: `$gsd-execute-phase 5`
 
 ---
 *Last updated: 2026-03-28 after Phase 4 verification and UI polish follow-through*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,18 +1,18 @@
 # State: Walnut Expense Analyser
 
 **Initialized:** 2026-03-27
-**Project status:** Phase 4 complete with UI polish and responsive-shell refinements, Phase 5 planned and ready for execution
-**Roadmap status:** Release 1 Phases 1, 2, 3, and 4 complete
+**Project status:** Phase 5 complete, ready for Phase 6 discussion
+**Roadmap status:** Release 1 Phases 1, 2, 3, 4, and 5 complete
 
 ## Project Reference
 
 See: `.planning/PROJECT.md` (updated 2026-03-27)
 
 **Core value:** A household owner can reliably import local bank statements and quickly understand where the money goes without giving up privacy or trust in the numbers.
-**Current focus:** Phase 5 - Categories and Rules execution
+**Current focus:** Phase 6 - Dashboard Analytics discussion
 
 **Active implementation branch:** `phase/5-categories-and-rules`
-**Current branch focus:** Phase 5 implementation planning for starter categories, protected system taxonomy, and reusable rule behavior
+**Current branch focus:** Phase 5 implementation, verification, and handoff for starter categories, protected taxonomy, and reusable rules
 
 ## Current Position
 
@@ -30,6 +30,7 @@ See: `.planning/PROJECT.md` (updated 2026-03-27)
 - Strict ICICI import support in release 1
 - Dedicated review queue with mixed import gating
 - Starter categories and rules with user-rule precedence
+- Protected system taxonomy with optional user subcategories and preview-first bulk rule application
 - Premium dashboard with both themes
 - Full audit ledger, redacted diagnostics, and local crash reports
 - Duplicate candidates and worksheet/parser uncertainty persist as blocking review items
@@ -72,10 +73,11 @@ See: `.planning/PROJECT.md` (updated 2026-03-27)
 - 2026-03-28: Phase 5 research captured at `.planning/phases/05-categories-and-rules/05-RESEARCH.md`
 - 2026-03-28: Phase 5 UI design contract approved at `.planning/phases/05-categories-and-rules/05-UI-SPEC.md`
 - 2026-03-28: Phase 5 validation strategy and execution plans created at `.planning/phases/05-categories-and-rules/05-VALIDATION.md`, `.planning/phases/05-categories-and-rules/05-01-PLAN.md`, `.planning/phases/05-categories-and-rules/05-02-PLAN.md`, `.planning/phases/05-categories-and-rules/05-03-PLAN.md`, and `.planning/phases/05-categories-and-rules/05-04-PLAN.md`
+- 2026-03-28: Phase 5 executed with summaries at `.planning/phases/05-categories-and-rules/05-01-SUMMARY.md`, `.planning/phases/05-categories-and-rules/05-02-SUMMARY.md`, `.planning/phases/05-categories-and-rules/05-03-SUMMARY.md`, `.planning/phases/05-categories-and-rules/05-04-SUMMARY.md`, and `.planning/phases/05-categories-and-rules/05-VERIFICATION.md`
 
 ## Immediate Next Action
 
-Run `$gsd-execute-phase 5` to implement the planned taxonomy, rule engine, and Categories & Rules workspace.
+Run `$gsd-discuss-phase 6` to define the dashboard analytics surface and insight interactions.
 
 ---
-*Last updated: 2026-03-28 after Phase 5 planning*
+*Last updated: 2026-03-28 after Phase 5 execution*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,7 +1,7 @@
 # State: Walnut Expense Analyser
 
 **Initialized:** 2026-03-27
-**Project status:** Phase 4 complete with UI polish and responsive-shell refinements, ready for Phase 5 discussion
+**Project status:** Phase 4 complete with UI polish and responsive-shell refinements, Phase 5 planned and ready for execution
 **Roadmap status:** Release 1 Phases 1, 2, 3, and 4 complete
 
 ## Project Reference
@@ -9,10 +9,10 @@
 See: `.planning/PROJECT.md` (updated 2026-03-27)
 
 **Core value:** A household owner can reliably import local bank statements and quickly understand where the money goes without giving up privacy or trust in the numbers.
-**Current focus:** Phase 5 - Categories and Rules discussion
+**Current focus:** Phase 5 - Categories and Rules execution
 
-**Active implementation branch:** `phase/4-transaction-ledger-and-search`
-**Current branch focus:** Phase 4 delivery plus shell, lock-screen, import-workspace, and ledger polish refinements
+**Active implementation branch:** `phase/5-categories-and-rules`
+**Current branch focus:** Phase 5 implementation planning for starter categories, protected system taxonomy, and reusable rule behavior
 
 ## Current Position
 
@@ -68,10 +68,14 @@ See: `.planning/PROJECT.md` (updated 2026-03-27)
 - 2026-03-28: Phase 4 context, research, UI contract, validation, and execution plans created at `.planning/phases/04-transaction-ledger-and-search/`
 - 2026-03-28: Phase 4 executed with summaries at `.planning/phases/04-transaction-ledger-and-search/04-01-SUMMARY.md`, `.planning/phases/04-transaction-ledger-and-search/04-02-SUMMARY.md`, `.planning/phases/04-transaction-ledger-and-search/04-03-SUMMARY.md`, `.planning/phases/04-transaction-ledger-and-search/04-04-SUMMARY.md`, and `.planning/phases/04-transaction-ledger-and-search/04-VERIFICATION.md`
 - 2026-03-28: Phase 4 branch absorbed the active shell polish work, including responsive lock-screen behavior, multi-profile selection, import-workspace layout cleanup, and ledger summary/filter refinements
+- 2026-03-28: Phase 5 context gathered at `.planning/phases/05-categories-and-rules/05-CONTEXT.md`
+- 2026-03-28: Phase 5 research captured at `.planning/phases/05-categories-and-rules/05-RESEARCH.md`
+- 2026-03-28: Phase 5 UI design contract approved at `.planning/phases/05-categories-and-rules/05-UI-SPEC.md`
+- 2026-03-28: Phase 5 validation strategy and execution plans created at `.planning/phases/05-categories-and-rules/05-VALIDATION.md`, `.planning/phases/05-categories-and-rules/05-01-PLAN.md`, `.planning/phases/05-categories-and-rules/05-02-PLAN.md`, `.planning/phases/05-categories-and-rules/05-03-PLAN.md`, and `.planning/phases/05-categories-and-rules/05-04-PLAN.md`
 
 ## Immediate Next Action
 
-Run `$gsd-discuss-phase 5` to define the starter categories, user-category management, and reusable rule behavior.
+Run `$gsd-execute-phase 5` to implement the planned taxonomy, rule engine, and Categories & Rules workspace.
 
 ---
-*Last updated: 2026-03-28 after Phase 4 delivery polish and verification*
+*Last updated: 2026-03-28 after Phase 5 planning*

--- a/.planning/phases/05-categories-and-rules/05-01-PLAN.md
+++ b/.planning/phases/05-categories-and-rules/05-01-PLAN.md
@@ -1,0 +1,124 @@
+---
+phase: 05-categories-and-rules
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/shared/contracts/categories.ts
+  - src/shared/contracts/transactions.ts
+  - src/shared/contracts/app-state.ts
+  - src/preload/index.ts
+  - src/main/persistence/schema.ts
+  - src/main/persistence/db.ts
+  - src/main/ipc/categories.ts
+  - tests/unit/categories/category-repository.test.ts
+  - tests/unit/categories/rule-engine.test.ts
+autonomous: true
+requirements:
+  - CATR-02
+  - CATR-04
+  - CATR-05
+  - CATR-06
+must_haves:
+  truths:
+    - "Built-in categories and income subcategories are seeded as protected system taxonomy, not ad hoc labels in the renderer."
+    - "User-created categories live in the same hierarchy as system categories but remain the only categories that support destructive management actions."
+    - "Transactions and rules refer to durable category ids so renames and merges do not break later dashboard and audit phases."
+  artifacts:
+    - path: "src/shared/contracts/categories.ts"
+      provides: "Typed category and rule contracts shared across main, preload, and renderer"
+      contains: "CategoryTreeNodeSchema"
+    - path: "src/main/persistence/db.ts"
+      provides: "Repository-backed category taxonomy, starter rule storage, and protected system-category enforcement"
+      contains: "listCategories"
+    - path: "tests/unit/categories/category-repository.test.ts"
+      provides: "Regression coverage for seeded system taxonomy and user-category management safety"
+      contains: "cannot delete system category"
+  key_links:
+    - from: "src/main/ipc/categories.ts"
+      to: "src/preload/index.ts"
+      via: "typed IPC bridge for category and rule list/detail mutations"
+      pattern: "categories:list|rules:list"
+    - from: "src/main/persistence/db.ts"
+      to: "src/shared/contracts/transactions.ts"
+      via: "transaction rows now carry category ids plus readable path labels"
+      pattern: "categoryId|categoryPath"
+---
+
+<objective>
+Create the Phase 5 backend foundation: a protected hierarchical category taxonomy, starter categories and rules, durable category ids on transactions, and repository-safe user-category management.
+
+Purpose: Replace label-only categorization with a real local taxonomy so rules, dashboards, and audit flows can depend on stable ids and protected system defaults.
+Output: Shared category/rule contracts, seeded SQLite taxonomy and starter rules, durable transaction category references, and repository methods for safe category management.
+</objective>
+
+<execution_context>
+@C:/Users/BitBytes/.codex/get-shit-done/workflows/execute-plan.md
+@C:/Users/BitBytes/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/REQUIREMENTS.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/05-categories-and-rules/05-CONTEXT.md
+@.planning/phases/05-categories-and-rules/05-RESEARCH.md
+@.planning/phases/05-categories-and-rules/05-UI-SPEC.md
+@.planning/phases/05-categories-and-rules/05-VALIDATION.md
+@.planning/phases/04-transaction-ledger-and-search/04-03-SUMMARY.md
+@src/shared/contracts/transactions.ts
+@src/shared/contracts/app-state.ts
+@src/main/persistence/db.ts
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Define category and starter-rule contracts plus seeded system taxonomy</name>
+  <files>src/shared/contracts/categories.ts, src/shared/contracts/transactions.ts, src/shared/contracts/app-state.ts, src/preload/index.ts, tests/unit/categories/category-repository.test.ts, tests/unit/categories/rule-engine.test.ts</files>
+  <read_first>.planning/phases/05-categories-and-rules/05-CONTEXT.md, .planning/phases/05-categories-and-rules/05-RESEARCH.md, .planning/phases/05-categories-and-rules/05-UI-SPEC.md, src/shared/contracts/transactions.ts, src/shared/contracts/app-state.ts, src/preload/index.ts</read_first>
+  <behavior>
+    - Test 1: the system taxonomy seeds the agreed protected top-level categories plus income subcategories Salary, Business Income, Interest, Refund / Reimbursement Income, Investment Income, and Other Income.
+    - Test 2: transaction contracts expose durable `categoryId`, readable `categoryPath`, and rule-suggestion payloads that can prefill Phase 5 rule creation.
+    - Test 3: starter-rule contracts support description, amount range, type, tags, and debit/credit direction conditions plus category/type/tag actions.
+  </behavior>
+  <action>Create `src/shared/contracts/categories.ts` as the new Phase 5 contract module. Define typed schemas for `CategoryKind`, `CategoryTreeNode`, `CategoryCountSummary`, `CreateCategoryInput`, `UpdateCategoryInput`, `MergeCategoryInput`, `CategorizationRuleCondition`, `CategorizationRuleAction`, `CategorizationRuleSummary`, `RuleTestPreview`, `RuleApplyPreview`, and the request/response payloads for category and rule operations. Update `src/shared/contracts/transactions.ts` so ledger rows and detail payloads carry `categoryId` and `categoryPath` in addition to the existing human-readable label surfaces. Update `WalnutApi` and preload with concrete methods named `listCategories`, `createCategory`, `updateCategory`, `mergeCategory`, `deleteCategory`, `listRules`, `createRule`, `updateRule`, `toggleRule`, `deleteRule`, `testRule`, `previewRuleApplyToExisting`, and `applyRuleToExisting`. Write failing unit tests first that lock in the exact system taxonomy from D-02 and D-03 and the allowed rule condition/action surface from D-05 and D-06.</action>
+  <acceptance_criteria>`src/shared/contracts/categories.ts` exists and contains `CategoryTreeNodeSchema`, `CategorizationRuleSummarySchema`, and `RuleApplyPreviewSchema`; `src/shared/contracts/transactions.ts` contains `categoryId` and `categoryPath`; `src/shared/contracts/app-state.ts` and `src/preload/index.ts` expose the named category and rule methods; the new unit suites fail before implementation and explicitly assert the protected system taxonomy plus income subcategories.</acceptance_criteria>
+  <verify>
+    <automated>cmd /c npx vitest run tests/unit/categories/category-repository.test.ts tests/unit/categories/rule-engine.test.ts</automated>
+  </verify>
+  <done>Phase 5 has a typed contract surface and failing tests that lock the taxonomy, starter-rule shape, and durable category references before persistence work begins.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Persist the protected category hierarchy and safe user-category management in SQLite</name>
+  <files>src/main/persistence/schema.ts, src/main/persistence/db.ts, src/main/ipc/categories.ts, src/preload/index.ts, tests/unit/categories/category-repository.test.ts, tests/unit/categories/rule-engine.test.ts</files>
+  <read_first>.planning/phases/05-categories-and-rules/05-CONTEXT.md, .planning/phases/05-categories-and-rules/05-RESEARCH.md, src/main/persistence/schema.ts, src/main/persistence/db.ts, src/shared/contracts/categories.ts, tests/unit/categories/category-repository.test.ts</read_first>
+  <behavior>
+    - Test 1: system categories are seeded once, remain protected from delete and merge-as-source mistakes, and always remain listable in hierarchy queries.
+    - Test 2: user-created categories can be created, renamed, moved under a new parent, activated/deactivated, and deleted only when repository safety checks pass.
+    - Test 3: merging a user category migrates existing transaction `category_id` references immediately to the target category and blocks hierarchy cycles.
+  </behavior>
+  <action>Add SQLite tables and indexes for `categories` and `categorization_rules` in `src/main/persistence/schema.ts` and `src/main/persistence/db.ts`. Seed the exact protected category set from D-02 and the income subcategories from D-03, using `is_system`, `parent_id`, `is_active`, `is_income_category`, and `sort_order` columns. Extend `imported_transactions` with `category_id` and keep readable category labels as derived query output rather than the durable relational key. Implement repository methods named `listCategories`, `createCategory`, `updateCategory`, `mergeCategory`, and `deleteCategory` with hard enforcement that only user-created categories can be deleted, merged as a source, or moved. Block moving a category under itself or its descendants. Register the corresponding read/write IPC handlers in `src/main/ipc/categories.ts` and preload so renderer work can rely on repository-backed state from day one.</action>
+  <acceptance_criteria>`src/main/persistence/schema.ts` contains `categories` and `categorization_rules`; `src/main/persistence/db.ts` contains `listCategories`, `createCategory`, `updateCategory`, `mergeCategory`, and `deleteCategory`; `imported_transactions` has a durable `category_id` column; repository tests prove the exact built-in taxonomy is seeded, system categories are protected, user categories can be managed safely, and category merges migrate existing transactions immediately.</acceptance_criteria>
+  <verify>
+    <automated>cmd /c npx vitest run tests/unit/categories/category-repository.test.ts tests/unit/categories/rule-engine.test.ts</automated>
+  </verify>
+  <done>The local taxonomy is now real, protected, and safe to build UI and rule application on top of.</done>
+</task>
+
+</tasks>
+
+<verification>
+Run the category-repository and rule-engine unit suites. Confirm the seeded taxonomy matches the locked category list, income subcategories are present, system categories are protected, and user-category management plus merge migration work through SQLite-backed repository methods.
+</verification>
+
+<success_criteria>
+Phase 5 has a stable category foundation: durable category ids exist, built-in categories are protected, user categories are safely manageable, and later rule and dashboard work can depend on the taxonomy without label drift.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/05-categories-and-rules/05-01-SUMMARY.md`
+</output>

--- a/.planning/phases/05-categories-and-rules/05-01-SUMMARY.md
+++ b/.planning/phases/05-categories-and-rules/05-01-SUMMARY.md
@@ -1,0 +1,23 @@
+# Phase 5 Plan 01 Summary
+
+Completed the Phase 5 taxonomy and repository foundation.
+
+Delivered:
+- Shared category and rule contracts for hierarchy rows, editor inputs, previews, and bulk-apply flows
+- SQLite schema additions for durable category ids, rule storage, and transaction-to-category linkage
+- Protected system taxonomy seeding with the agreed starter category set and income subcategories
+- Repository operations for user-category create, update, merge, deactivate, and delete with system-category protection
+- Starter categorization seeds and category-path hydration in transaction mapping
+
+Key files:
+- `src/shared/contracts/categories.ts`
+- `src/shared/contracts/transactions.ts`
+- `src/shared/contracts/app-state.ts`
+- `src/preload/index.ts`
+- `src/main/persistence/schema.ts`
+- `src/main/persistence/db.ts`
+- `src/main/ipc/categories.ts`
+- `src/main/main.ts`
+
+Result:
+- Walnut now has a durable local taxonomy model with protected defaults and safe user-category management instead of flat labels only.

--- a/.planning/phases/05-categories-and-rules/05-02-PLAN.md
+++ b/.planning/phases/05-categories-and-rules/05-02-PLAN.md
@@ -1,0 +1,126 @@
+---
+phase: 05-categories-and-rules
+plan: 02
+type: execute
+wave: 2
+depends_on:
+  - 05-01-PLAN.md
+files_modified:
+  - src/shared/contracts/categories.ts
+  - src/shared/contracts/transactions.ts
+  - src/preload/index.ts
+  - src/main/persistence/db.ts
+  - src/main/ipc/categories.ts
+  - src/main/ipc/transactions.ts
+  - src/renderer/features/transactions/TransactionDetailDrawer.tsx
+  - tests/unit/categories/rule-engine.test.ts
+  - tests/unit/categories/rule-preview.test.ts
+  - tests/unit/transactions/rule-suggestion.test.tsx
+autonomous: true
+requirements:
+  - CATR-01
+  - CATR-03
+  - CATR-06
+must_haves:
+  truths:
+    - "Starter rules and user rules are deterministic, explainable, and repository-owned rather than renderer-owned."
+    - "Most-specific user rule wins automatically, but bulk application to existing transactions always uses a preview-first flow."
+    - "Ledger edits save first and only then offer a prefilled reusable-rule flow."
+  artifacts:
+    - path: "src/main/persistence/db.ts"
+      provides: "Rule matching, specificity scoring, preview sampling, and bulk apply operations"
+      contains: "previewRuleApplyToExisting"
+    - path: "src/shared/contracts/categories.ts"
+      provides: "Typed rule preview and apply-to-existing payloads used by both transactions and management UI"
+      contains: "CategorizationRuleConditionSchema"
+    - path: "tests/unit/transactions/rule-suggestion.test.tsx"
+      provides: "Coverage for the post-save prefilled rule-suggestion handoff from the transaction drawer"
+      contains: "Create a reusable rule"
+  key_links:
+    - from: "src/main/ipc/transactions.ts"
+      to: "src/renderer/features/transactions/TransactionDetailDrawer.tsx"
+      via: "post-save rule suggestion payload and follow-on side flow"
+      pattern: "ruleSuggestion"
+    - from: "src/main/persistence/db.ts"
+      to: "src/main/ipc/categories.ts"
+      via: "rule test previews and apply-to-existing previews with count plus sample transactions"
+      pattern: "testRule|applyRuleToExisting"
+---
+
+<objective>
+Add the Phase 5 rule engine: starter and user-rule evaluation, deterministic most-specific precedence, preview-first apply-to-existing flows, and the reusable-rule suggestion hook from transaction edits.
+
+Purpose: Turn categorization into a trustworthy automation layer that stays conservative, previewable, and fully under user control.
+Output: Repository-backed rule evaluation, preview/apply operations, starter-rule behavior on realistic transactions, and a transaction-drawer rule suggestion flow with prefilled values.
+</objective>
+
+<execution_context>
+@C:/Users/BitBytes/.codex/get-shit-done/workflows/execute-plan.md
+@C:/Users/BitBytes/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/REQUIREMENTS.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/05-categories-and-rules/05-CONTEXT.md
+@.planning/phases/05-categories-and-rules/05-RESEARCH.md
+@.planning/phases/05-categories-and-rules/05-UI-SPEC.md
+@.planning/phases/05-categories-and-rules/05-VALIDATION.md
+@src/shared/contracts/categories.ts
+@src/shared/contracts/transactions.ts
+@src/main/persistence/db.ts
+@src/main/ipc/transactions.ts
+@src/renderer/features/transactions/TransactionDetailDrawer.tsx
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Implement deterministic rule evaluation, previews, and apply-to-existing operations</name>
+  <files>src/shared/contracts/categories.ts, src/main/persistence/db.ts, src/main/ipc/categories.ts, src/preload/index.ts, tests/unit/categories/rule-engine.test.ts, tests/unit/categories/rule-preview.test.ts</files>
+  <read_first>.planning/phases/05-categories-and-rules/05-CONTEXT.md, .planning/phases/05-categories-and-rules/05-RESEARCH.md, src/shared/contracts/categories.ts, src/main/persistence/db.ts, tests/unit/categories/rule-engine.test.ts, tests/unit/categories/rule-preview.test.ts</read_first>
+  <behavior>
+    - Test 1: rules match on description, amount range, normalized type, tags, and debit/credit direction, and the most specific matching user rule wins deterministically.
+    - Test 2: starter rules categorize realistic imported rows into the seeded taxonomy without preventing user override later.
+    - Test 3: previewing apply-to-existing returns an affected count plus a sample list, and applying the rule updates existing matching transactions only after confirmation.
+  </behavior>
+  <action>Implement repository-owned rule storage and evaluation in `src/main/persistence/db.ts`. Represent each rule with typed `conditions_json`, `actions_json`, `specificity_score`, `is_enabled`, and an `apply_to_existing_default` flag. Score specificity concretely from populated conditions so description terms outrank amount ranges, amount ranges outrank type and direction, and tags act as an additional narrowing signal; keep any tie-breaker stable by creation order. Add `listRules`, `createRule`, `updateRule`, `toggleRule`, `deleteRule`, `testRule`, `previewRuleApplyToExisting`, and `applyRuleToExisting` repository methods and IPC handlers. Ensure apply-to-existing does not silently run: `previewRuleApplyToExisting` must return both `matchCount` and a concise `samples` list, and `applyRuleToExisting` must update only the previewed match set inside one repository transaction.</action>
+  <acceptance_criteria>`src/main/persistence/db.ts` contains `testRule`, `previewRuleApplyToExisting`, and `applyRuleToExisting`; `tests/unit/categories/rule-engine.test.ts` proves most-specific matching wins deterministically; `tests/unit/categories/rule-preview.test.ts` proves count-plus-sample previews and confirmed bulk application; the rule contracts include description, amount range, type, tags, and direction conditions plus category/type/tag actions.</acceptance_criteria>
+  <verify>
+    <automated>cmd /c npx vitest run tests/unit/categories/rule-engine.test.ts tests/unit/categories/rule-preview.test.ts</automated>
+  </verify>
+  <done>Phase 5 now has a deterministic local rule engine with safe preview-first bulk application for existing transactions.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Wire transaction-edit rule suggestions into the typed Phase 5 rule flow</name>
+  <files>src/shared/contracts/transactions.ts, src/main/ipc/transactions.ts, src/renderer/features/transactions/TransactionDetailDrawer.tsx, src/preload/index.ts, tests/unit/transactions/rule-suggestion.test.tsx, tests/unit/categories/rule-preview.test.ts</files>
+  <read_first>.planning/phases/05-categories-and-rules/05-CONTEXT.md, .planning/phases/05-categories-and-rules/05-UI-SPEC.md, src/shared/contracts/transactions.ts, src/main/ipc/transactions.ts, src/renderer/features/transactions/TransactionDetailDrawer.tsx</read_first>
+  <behavior>
+    - Test 1: after a ledger edit saves, the user can open a prefilled rule-creation side flow instead of losing the saved edit.
+    - Test 2: the suggested rule payload is derived from the saved transaction change and prepopulates conditions/actions rather than asking the user to start from scratch.
+    - Test 3: manual type and category corrections can feed reusable rule creation without interrupting the save flow.
+  </behavior>
+  <action>Extend the existing transaction update result so `ruleSuggestion` carries the prefilled Phase 5 rule draft: description terms, direction, normalized type context, suggested category action, and any tags changed in the save. Update `src/main/ipc/transactions.ts` so update responses include that payload only after the save succeeds. Refactor `src/renderer/features/transactions/TransactionDetailDrawer.tsx` to replace the lightweight suggestion message with a clear `Create a reusable rule` action that hands off the typed draft into the future Categories & Rules side-flow contract. Keep the transaction save immediate and authoritative; the suggestion is an optional next step, never a blocking confirmation.</action>
+  <acceptance_criteria>`src/shared/contracts/transactions.ts` exposes a rule-suggestion draft payload with concrete prefilled fields; `TransactionDetailDrawer.tsx` shows a `Create a reusable rule` action after relevant saves; the rule-suggestion unit test proves the save completes before the reusable-rule handoff appears; no transaction save path requires rule creation to finish.</acceptance_criteria>
+  <verify>
+    <automated>cmd /c npx vitest run tests/unit/transactions/rule-suggestion.test.tsx tests/unit/categories/rule-preview.test.ts</automated>
+  </verify>
+  <done>Ledger corrections now feed Phase 5 rule creation cleanly, without interrupting the user’s transaction-fix workflow.</done>
+</task>
+
+</tasks>
+
+<verification>
+Run the rule-engine, rule-preview, and rule-suggestion unit suites. Confirm specificity is deterministic, previews always show count plus sample transactions before bulk changes, and ledger saves still complete before rule creation is offered.
+</verification>
+
+<success_criteria>
+Phase 5 automation is trustworthy: user rules outrank heuristics consistently, bulk application is preview-first, and transaction edits can seed reusable rules without breaking the local save flow.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/05-categories-and-rules/05-02-SUMMARY.md`
+</output>

--- a/.planning/phases/05-categories-and-rules/05-02-SUMMARY.md
+++ b/.planning/phases/05-categories-and-rules/05-02-SUMMARY.md
@@ -1,0 +1,21 @@
+# Phase 5 Plan 02 Summary
+
+Completed the deterministic rule engine and preview-first apply flows.
+
+Delivered:
+- Rule storage and normalization for description keywords, amount ranges, type, tags, and debit/credit direction
+- Specificity scoring so the most specific user rule wins consistently
+- Rule CRUD, enable/disable flows, and sample-preview APIs for test/apply behavior
+- Preview-first apply-to-existing flow with match counts and sample transaction receipts
+- Ledger edit handoff that turns a saved type/category correction into a prefilled reusable rule draft
+
+Key files:
+- `src/main/persistence/db.ts`
+- `src/main/ipc/categories.ts`
+- `src/shared/contracts/categories.ts`
+- `src/shared/contracts/transactions.ts`
+- `src/renderer/features/transactions/TransactionDetailDrawer.tsx`
+- `src/renderer/features/transactions/TransactionsScreen.tsx`
+
+Result:
+- Categorization logic is now reusable and deterministic, with user intent captured as rule drafts instead of one-off hidden heuristics.

--- a/.planning/phases/05-categories-and-rules/05-03-PLAN.md
+++ b/.planning/phases/05-categories-and-rules/05-03-PLAN.md
@@ -1,0 +1,128 @@
+---
+phase: 05-categories-and-rules
+plan: 03
+type: execute
+wave: 3
+depends_on:
+  - 05-01-PLAN.md
+  - 05-02-PLAN.md
+files_modified:
+  - src/renderer/App.tsx
+  - src/renderer/features/app-shell/AppShell.tsx
+  - src/renderer/features/categories-rules/CategoriesRulesScreen.tsx
+  - src/renderer/features/categories-rules/CategoryPane.tsx
+  - src/renderer/features/categories-rules/RulePane.tsx
+  - src/renderer/features/categories-rules/CategoryEditorPanel.tsx
+  - src/renderer/features/categories-rules/RuleEditorPanel.tsx
+  - src/renderer/features/categories-rules/RulePreviewPanel.tsx
+  - tests/unit/categories-rules-screen.test.tsx
+  - tests/unit/transactions/rule-suggestion.test.tsx
+autonomous: true
+requirements:
+  - CATR-01
+  - CATR-03
+  - CATR-04
+  - CATR-05
+  - CATR-06
+must_haves:
+  truths:
+    - "Categories and rules live in one dedicated left-rail destination with two visible operational panes."
+    - "System categories read as protected and stable, while user categories clearly expose manageable actions and live counts."
+    - "Rule creation, editing, testing, and apply-to-existing previews stay in-context through side panels and embedded preview surfaces rather than detached screens."
+  artifacts:
+    - path: "src/renderer/features/categories-rules/CategoriesRulesScreen.tsx"
+      provides: "Dual-pane workspace tying category hierarchy, rule list, counts, and preview flows together"
+      contains: "Categories & Rules"
+    - path: "src/renderer/features/categories-rules/RulePreviewPanel.tsx"
+      provides: "Preview-first sample list and affected-count confirmation for apply-to-existing flows"
+      contains: "Review affected transactions"
+    - path: "tests/unit/categories-rules-screen.test.tsx"
+      provides: "Renderer coverage for protected-system cues, counts, side-panel editing, and preview surfaces"
+      contains: "No custom categories yet"
+  key_links:
+    - from: "src/renderer/features/categories-rules/RuleEditorPanel.tsx"
+      to: "src/renderer/features/categories-rules/RulePreviewPanel.tsx"
+      via: "test rule and apply-to-existing preview with count plus sample list"
+      pattern: "matchCount|samples"
+    - from: "src/renderer/features/transactions/TransactionDetailDrawer.tsx"
+      to: "src/renderer/features/categories-rules/CategoriesRulesScreen.tsx"
+      via: "prefilled rule draft handoff into the rules side flow"
+      pattern: "ruleSuggestionDraft"
+---
+
+<objective>
+Build the Phase 5 Categories & Rules workspace: a dual-pane management surface for the taxonomy, rules list, previews, and in-context side-panel editing.
+
+Purpose: Give users one trustworthy place to inspect the protected taxonomy, manage their own categories, understand automation impact, and create or edit rules without leaving the local workflow.
+Output: A new Categories & Rules destination in the left rail, category and rule panes with live counts, side-panel edit/create flows, and preview-first apply-to-existing UX.
+</objective>
+
+<execution_context>
+@C:/Users/BitBytes/.codex/get-shit-done/workflows/execute-plan.md
+@C:/Users/BitBytes/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/REQUIREMENTS.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/05-categories-and-rules/05-CONTEXT.md
+@.planning/phases/05-categories-and-rules/05-RESEARCH.md
+@.planning/phases/05-categories-and-rules/05-UI-SPEC.md
+@.planning/phases/05-categories-and-rules/05-VALIDATION.md
+@src/renderer/App.tsx
+@src/renderer/features/app-shell/AppShell.tsx
+@src/renderer/features/transactions/TransactionDetailDrawer.tsx
+@src/renderer/styles/tokens.css
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add the Categories & Rules workspace and categories-pane management flows</name>
+  <files>src/renderer/App.tsx, src/renderer/features/app-shell/AppShell.tsx, src/renderer/features/categories-rules/CategoriesRulesScreen.tsx, src/renderer/features/categories-rules/CategoryPane.tsx, src/renderer/features/categories-rules/CategoryEditorPanel.tsx, tests/unit/categories-rules-screen.test.tsx</files>
+  <read_first>.planning/phases/05-categories-and-rules/05-CONTEXT.md, .planning/phases/05-categories-and-rules/05-UI-SPEC.md, src/renderer/App.tsx, src/renderer/features/app-shell/AppShell.tsx, src/renderer/features/transactions/TransactionsScreen.tsx, src/renderer/styles/tokens.css</read_first>
+  <behavior>
+    - Test 1: the left rail exposes a dedicated `Categories & Rules` destination and the screen renders categories and rules side-by-side on standard desktop widths.
+    - Test 2: the categories pane shows one hierarchy with system and user categories, protected system cues, active/inactive state, and mapped transaction counts.
+    - Test 3: user-category create, rename, move, merge, activate/deactivate, and delete flows open in-context side panels instead of detached screens.
+  </behavior>
+  <action>Create a new `src/renderer/features/categories-rules/` feature folder and wire it into the shell as a left-rail destination labeled exactly `Categories & Rules`. Build a dual-pane screen whose left pane is the category hierarchy. Each category row must show the category name, parent context when applicable, active/inactive state, and mapped transaction count, with system categories visually marked as protected and user categories exposing row actions. Add a category editor side panel for create, rename, move-under-parent, merge, activate/deactivate, and delete actions. Preserve the existing Walnut shell, token system, rounded surfaces, and desktop-first split-pane layout from the UI contract.</action>
+  <acceptance_criteria>`src/renderer/App.tsx` routes to a `Categories & Rules` screen; `CategoriesRulesScreen.tsx` renders a visible dual-pane workspace; the categories pane shows system and user categories in one hierarchy with counts and protected-system cues; the unit screen test covers the categories empty state, protected rows, and category side-panel operations.</acceptance_criteria>
+  <verify>
+    <automated>cmd /c npx vitest run tests/unit/categories-rules-screen.test.tsx</automated>
+  </verify>
+  <done>The product now has a first-class Categories & Rules destination with a trustworthy taxonomy-management pane.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Build the rules pane, test-preview surface, and prefilled reusable-rule flow</name>
+  <files>src/renderer/features/categories-rules/RulePane.tsx, src/renderer/features/categories-rules/RuleEditorPanel.tsx, src/renderer/features/categories-rules/RulePreviewPanel.tsx, src/renderer/features/categories-rules/CategoriesRulesScreen.tsx, src/renderer/features/transactions/TransactionDetailDrawer.tsx, tests/unit/categories-rules-screen.test.tsx, tests/unit/transactions/rule-suggestion.test.tsx</files>
+  <read_first>.planning/phases/05-categories-and-rules/05-CONTEXT.md, .planning/phases/05-categories-and-rules/05-UI-SPEC.md, src/renderer/features/transactions/TransactionDetailDrawer.tsx, src/shared/contracts/categories.ts, src/shared/contracts/transactions.ts</read_first>
+  <behavior>
+    - Test 1: the rules pane shows each rule with name, enabled/disabled state, readable condition summary, readable action summary, and affected transaction count.
+    - Test 2: creating or editing a rule can test against matches and open a preview showing affected count plus sample transaction rows before applying to existing transactions.
+    - Test 3: the post-save transaction rule suggestion can open a prefilled rule editor side flow without losing the user’s ledger context.
+  </behavior>
+  <action>Build the right-hand rules pane inside `CategoriesRulesScreen.tsx` using dedicated `RulePane`, `RuleEditorPanel`, and `RulePreviewPanel` components. Each rule row must render a readable summary of match conditions and actions, an enabled/disabled state, and an affected transaction count. The rule editor side panel must expose the exact Phase 5 condition/action set from D-05 and D-06 and provide actions to test the rule, enable or disable it, save it, and preview apply-to-existing. The preview surface must headline `Review affected transactions` and show both `matchCount` and a concise sample list before confirmation. Wire the transaction drawer rule-suggestion CTA into this flow with prefilled values rather than forcing users to start from an empty rule.</action>
+  <acceptance_criteria>The rules pane renders readable rule summaries and counts; `RulePreviewPanel.tsx` shows count plus sample-list previews before apply-to-existing; the reusable-rule handoff from `TransactionDetailDrawer.tsx` opens a prefilled rule flow; renderer tests cover rule creation/editing, test-preview, and prefilled suggestions.</acceptance_criteria>
+  <verify>
+    <automated>cmd /c npx vitest run tests/unit/categories-rules-screen.test.tsx tests/unit/transactions/rule-suggestion.test.tsx</automated>
+  </verify>
+  <done>The Phase 5 management UI is complete: users can understand, create, test, and preview categorization rules in one in-context workspace.</done>
+</task>
+
+</tasks>
+
+<verification>
+Run the Categories & Rules renderer suite plus the transaction rule-suggestion suite. Confirm the workspace stays dual-pane, protected categories read correctly, rule previews show count plus sample transactions, and transaction-driven rule creation opens with prefilled data.
+</verification>
+
+<success_criteria>
+Phase 5 has a usable control surface: categories and rules are visible together, protected system behavior is obvious, and users can safely manage and preview automation without leaving the current context.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/05-categories-and-rules/05-03-SUMMARY.md`
+</output>

--- a/.planning/phases/05-categories-and-rules/05-03-SUMMARY.md
+++ b/.planning/phases/05-categories-and-rules/05-03-SUMMARY.md
@@ -1,0 +1,23 @@
+# Phase 5 Plan 03 Summary
+
+Completed the Categories & Rules workspace and side-panel management flows.
+
+Delivered:
+- New left-rail `Categories & Rules` destination in the main shell
+- Dual-pane workspace with categories on one side and rules on the other
+- Category editor panel for create, edit, merge, activate/deactivate, and delete flows
+- Rule editor panel for rule authoring, testing, previewing existing matches, and save/delete flows
+- Preview panel for apply-to-existing review before bulk category changes
+
+Key files:
+- `src/renderer/App.tsx`
+- `src/renderer/features/categories-rules/CategoriesRulesScreen.tsx`
+- `src/renderer/features/categories-rules/CategoryPane.tsx`
+- `src/renderer/features/categories-rules/CategoryEditorPanel.tsx`
+- `src/renderer/features/categories-rules/RulePane.tsx`
+- `src/renderer/features/categories-rules/RuleEditorPanel.tsx`
+- `src/renderer/features/categories-rules/RulePreviewPanel.tsx`
+- `src/renderer/mockWalnutApi.ts`
+
+Result:
+- Phase 5 now has a dedicated operational workspace where protected starter taxonomy, user categories, and reusable rules can be managed in one place.

--- a/.planning/phases/05-categories-and-rules/05-04-PLAN.md
+++ b/.planning/phases/05-categories-and-rules/05-04-PLAN.md
@@ -1,0 +1,104 @@
+---
+phase: 05-categories-and-rules
+plan: 04
+type: execute
+wave: 4
+depends_on:
+  - 05-01-PLAN.md
+  - 05-02-PLAN.md
+  - 05-03-PLAN.md
+files_modified:
+  - tests/unit/categories/category-repository.test.ts
+  - tests/unit/categories/rule-engine.test.ts
+  - tests/unit/categories/rule-preview.test.ts
+  - tests/unit/categories-rules-screen.test.tsx
+  - tests/unit/transactions/rule-suggestion.test.tsx
+  - tests/e2e/categories-rules.spec.ts
+  - .planning/phases/05-categories-and-rules/05-VERIFICATION.md
+autonomous: true
+requirements:
+  - CATR-01
+  - CATR-02
+  - CATR-03
+  - CATR-04
+  - CATR-05
+  - CATR-06
+must_haves:
+  truths:
+    - "Phase 5 is not complete until taxonomy seeding, rule precedence, preview-first bulk apply, and the dual-pane management UI are covered by both unit and end-to-end tests."
+    - "Rule changes that touch existing transactions remain preview-first and never silently rewrite history."
+    - "The Categories & Rules workspace remains keyboard reachable and visually trustworthy in the existing Walnut shell."
+---
+
+<objective>
+Close Phase 5 with complete regression coverage, end-to-end category/rule workflows, and a formal verification handoff.
+
+Purpose: Prove the taxonomy, rule engine, and management UI work together on realistic local data before Phase 6 depends on them for dashboard analytics.
+Output: Full Phase 5 unit and e2e coverage plus a verification report that maps execution back to every category and rule requirement.
+</objective>
+
+<execution_context>
+@C:/Users/BitBytes/.codex/get-shit-done/workflows/execute-plan.md
+@C:/Users/BitBytes/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/05-categories-and-rules/05-VALIDATION.md
+@.planning/phases/05-categories-and-rules/05-UI-SPEC.md
+@tests/unit/categories/category-repository.test.ts
+@tests/unit/categories/rule-engine.test.ts
+@tests/unit/categories/rule-preview.test.ts
+@tests/unit/categories-rules-screen.test.tsx
+@tests/unit/transactions/rule-suggestion.test.tsx
+</context>
+
+<tasks>
+
+<task type="auto" tdd="false">
+  <name>Task 1: Fill the Phase 5 unit and end-to-end coverage gaps</name>
+  <files>tests/unit/categories/category-repository.test.ts, tests/unit/categories/rule-engine.test.ts, tests/unit/categories/rule-preview.test.ts, tests/unit/categories-rules-screen.test.tsx, tests/unit/transactions/rule-suggestion.test.tsx, tests/e2e/categories-rules.spec.ts</files>
+  <read_first>.planning/phases/05-categories-and-rules/05-VALIDATION.md, .planning/phases/05-categories-and-rules/05-UI-SPEC.md, tests/unit/categories/category-repository.test.ts, tests/unit/categories/rule-engine.test.ts, tests/unit/categories-rules-screen.test.tsx</read_first>
+  <behavior>
+    - verify the exact protected system taxonomy and income subcategories
+    - verify user-category create, move, merge, activate/deactivate, and delete behavior
+    - verify most-specific rule precedence, rule previews, and apply-to-existing confirmation flows
+    - verify the end-to-end category/rule management loop from transaction edit suggestion through previewed historical application
+  </behavior>
+  <action>Fill all Wave 0 gaps declared in `05-VALIDATION.md`. Expand repository tests for taxonomy seeding, protection, merge migration, and deterministic specificity. Expand renderer tests for the dual-pane workspace, live counts, side panels, and preview surfaces. Add a Playwright spec named `tests/e2e/categories-rules.spec.ts` that imports realistic transactions, opens `Categories & Rules`, creates a user category, creates or edits a reusable rule, previews the affected count plus sample list, applies to existing transactions, and verifies the resulting categorization changes in the transaction workspace.</action>
+  <acceptance_criteria>All planned Phase 5 unit and end-to-end tests exist and pass; the e2e flow covers category creation, rule creation or editing, preview-before-apply, and visible transaction categorization changes; repository and renderer suites cover every locked requirement from CATR-01 through CATR-06.</acceptance_criteria>
+  <verify>
+    <automated>cmd /c npx vitest run tests/unit/categories/*.test.ts tests/unit/categories-rules-screen.test.tsx tests/unit/transactions/rule-suggestion.test.tsx && cmd /c npx playwright test tests/e2e/categories-rules.spec.ts</automated>
+  </verify>
+  <done>Phase 5 behavior is protected by a full regression surface rather than relying on manual spot checks.</done>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 2: Complete formal verification and execution handoff</name>
+  <files>.planning/phases/05-categories-and-rules/05-VERIFICATION.md</files>
+  <read_first>.planning/phases/05-categories-and-rules/05-VALIDATION.md, .planning/phases/05-categories-and-rules/05-CONTEXT.md, .planning/phases/05-categories-and-rules/05-RESEARCH.md, .planning/phases/05-categories-and-rules/05-UI-SPEC.md</read_first>
+  <behavior>
+    - record the executed commands and outcomes
+    - map validation back to CATR-01 through CATR-06
+    - note any remaining residual risks or future polish items clearly
+  </behavior>
+  <action>Write the Phase 5 verification report after all tests pass. Include the exact final commands, requirement mapping for `CATR-01` through `CATR-06`, notes on protected-system behavior, preview-first bulk application, and any residual follow-up items that belong in Phase 6, Phase 7, or Phase 10 instead of quietly extending Phase 5 scope.</action>
+  <acceptance_criteria>`05-VERIFICATION.md` exists, references the executed commands, closes the loop on CATR-01 through CATR-06, and calls out any remaining residual risks explicitly.</acceptance_criteria>
+  <verify>
+    <automated>cmd /c npm run test:unit && cmd /c npx playwright test tests/e2e/categories-rules.spec.ts</automated>
+  </verify>
+  <done>Phase 5 ends with a clean verification artifact that downstream dashboard and audit work can trust.</done>
+</task>
+
+</tasks>
+
+<verification>
+Run the full Phase 5 unit suite slice and the dedicated categories-rules Playwright flow. Confirm protected taxonomy behavior, deterministic rule precedence, preview-first bulk apply, and the dual-pane workspace all behave as planned.
+</verification>
+
+<success_criteria>
+Phase 5 is complete only when categories and rules are both implemented and verified: starter defaults work, user control remains authoritative, and the product can now feed dashboard analytics from stable local categorization data.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/05-categories-and-rules/05-04-SUMMARY.md`
+</output>

--- a/.planning/phases/05-categories-and-rules/05-04-SUMMARY.md
+++ b/.planning/phases/05-categories-and-rules/05-04-SUMMARY.md
@@ -1,0 +1,26 @@
+# Phase 5 Plan 04 Summary
+
+Completed Phase 5 verification coverage and handoff readiness.
+
+Delivered:
+- Repository tests for seeded taxonomy, system-category protection, category merge behavior, and rule specificity
+- Renderer tests for the Categories & Rules workspace and transaction-to-rule handoff
+- Browser coverage for the new Categories & Rules workspace plus existing transaction handoff behavior
+- Responsive side-panel fix so rule/category actions remain reachable in shorter windows
+- Updated roadmap/state/docs for Phase 5 completion and Phase 6 readiness
+
+Key files:
+- `tests/unit/categories/category-repository.test.ts`
+- `tests/unit/categories/rule-engine.test.ts`
+- `tests/unit/categories-rules-screen.test.tsx`
+- `tests/unit/transactions/rule-suggestion.test.tsx`
+- `tests/e2e/categories-rules.spec.ts`
+- `tests/e2e/transaction-ledger.spec.ts`
+- `.planning/STATE.md`
+- `.planning/ROADMAP.md`
+- `.planning/REQUIREMENTS.md`
+- `docs/ROADMAP.md`
+- `docs/DELIVERY.md`
+
+Result:
+- Phase 5 ships with repository, renderer, and browser coverage that validates taxonomy management, rule behavior, and ledger handoff end to end.

--- a/.planning/phases/05-categories-and-rules/05-CONTEXT.md
+++ b/.planning/phases/05-categories-and-rules/05-CONTEXT.md
@@ -1,0 +1,131 @@
+# Phase 5: Categories and Rules - Context
+
+**Gathered:** 2026-03-28
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Turn imported and editable transactions into a trustworthy categorization system. This phase covers the built-in category taxonomy, income categorization, starter categorization rules, rule precedence, user-created category management, rule testing/management UX, and controlled re-categorization behavior for existing transactions. Dashboard analytics, audit-screen surfacing, and broader rule-system expansion remain separate phases.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Category Model
+- **D-01:** Phase 5 uses top-level categories with optional subcategories.
+- **D-02:** The built-in system taxonomy should keep the agreed base set:
+  - Food & Dining
+  - Groceries
+  - Shopping
+  - Bills & Utilities
+  - Rent / Housing
+  - Transport
+  - Travel
+  - Healthcare
+  - Entertainment
+  - Education
+  - Insurance
+  - Taxes & Fees
+  - Cash / ATM
+  - Transfers
+  - Credit Card Payment
+  - Income
+  - Refunds / Reimbursements
+  - Investments / Savings
+  - Uncategorized
+- **D-03:** Income ships with built-in subcategories such as Salary, Business Income, Interest, Refund / Reimbursement Income, Investment Income, and Other Income.
+- **D-04:** User-created categories may exist either as top-level categories or as subcategories under an existing parent.
+
+### Rule Model
+- **D-05:** Phase 5 rules can match on description, amount range, transaction type, tags, and debit/credit direction.
+- **D-06:** Phase 5 rules can assign category/subcategory, type, and tags.
+- **D-07:** When multiple user rules match, the most specific rule should win automatically.
+- **D-08:** After a ledger edit is saved, Walnut should offer a rule-creation side flow with prefilled values rather than interrupting the save flow.
+
+### Categories and Rules UX
+- **D-09:** Categories and rules should live in one screen with two side-by-side panes.
+- **D-10:** User-created categories support create, rename, move under parent, merge, activate/deactivate, and delete.
+- **D-11:** Rules support create, edit, test against sample matches, enable/disable, and delete.
+- **D-12:** The screen should show how many transactions currently map to a category or are affected by a rule.
+
+### Re-categorization Behavior
+- **D-13:** New rules apply to future transactions by default, with an optional apply-to-existing step.
+- **D-14:** Editing an existing rule should offer a preview and optional re-apply to existing matching transactions.
+- **D-15:** Merging a category should migrate existing transactions immediately to the target category.
+- **D-16:** Before applying a rule to existing transactions, Walnut should show both a count and a sample list of affected transactions.
+
+### At the Agent's Discretion
+- Exact built-in subcategory distribution under non-income parents, as long as it remains intuitive and consistent with the protected system taxonomy.
+- Exact specificity scoring for rule precedence, provided it remains explainable and stable.
+- Exact pane proportions and interaction details for the dual-pane Categories and Rules screen.
+- Exact wording of rule previews and re-apply confirmations, provided users can understand the impact before changing existing transactions.
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Project planning artifacts
+- `.planning/PROJECT.md` - Product trust posture, local-first privacy model, and release-1 scope
+- `.planning/REQUIREMENTS.md` - Category and rule requirements `CATR-01` through `CATR-06`
+- `.planning/ROADMAP.md` - Phase 5 goal, success criteria, and relation to nearby phases
+- `.planning/STATE.md` - Current project position and next-step expectations
+- `.planning/phases/04-transaction-ledger-and-search/04-CONTEXT.md` - Prior phase decisions around transaction editing and rule-suggestion hooks
+
+### Existing implementation
+- `src/renderer/features/transactions/TransactionsScreen.tsx` - Current transaction workspace and edit flow that Phase 5 should build on
+- `src/renderer/features/transactions/TransactionDetailDrawer.tsx` - Existing correction surface where rule suggestions currently begin
+- `src/main/persistence/db.ts` - Current transaction persistence, query, and update layer to extend for categories and rules
+- `src/shared/contracts/transactions.ts` - Existing transaction contracts that should gain category/rule shapes rather than being replaced
+- `src/renderer/App.tsx` - Current shell routing and left-rail destinations
+- `src/renderer/styles/tokens.css` - Existing Walnut visual system that Categories and Rules should preserve
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- Phase 4 already introduced a dedicated Transactions workspace, filtered ledger queries, and immediate-save editing, which gives Phase 5 a strong base for category assignment and rule suggestions.
+- The current typed preload/main-process boundary is already in place and should remain the source of truth for category/rule operations.
+- The shell already supports domain-specific left-rail destinations and split-pane workflows, which fits the Phase 5 two-pane screen decision.
+
+### Established Patterns
+- Corrective changes should save against authoritative repository state instead of relying on long-lived renderer-only caches.
+- The product favors conservative automation with strong user override.
+- Protected system data and editable user data should remain clearly separated in both storage and UI behavior.
+
+### Integration Points
+- Phase 5 must attach cleanly to Phase 4 transaction editing and rule-suggestion flow.
+- Phase 6 dashboard analytics will depend on the Phase 5 categorization model being stable and queryable.
+- Phase 7 audit work should be able to attach to category/rule mutations without redesigning these Phase 5 payloads later.
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- The category system should feel opinionated enough to be useful on day one, but not rigid enough to force awkward personal finance habits.
+- Rules should feel powerful but understandable; matching and precedence need to be explainable in the UI.
+- Re-apply flows must help users trust bulk categorization changes by previewing impact before they touch existing history.
+- The Categories and Rules screen should feel like an operational control surface, not a buried settings form.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- Broader rule-system expansion beyond Phase 5 belongs to Phase 10.
+- Dashboard consumption of categories and rules belongs to Phase 6.
+- Audit-screen browsing of category/rule edits belongs to Phase 7.
+- Saved filters and broader workflow polish remain later concerns.
+
+</deferred>
+
+---
+*Phase: 05-categories-and-rules*
+*Context gathered: 2026-03-28*

--- a/.planning/phases/05-categories-and-rules/05-DISCUSSION-LOG.md
+++ b/.planning/phases/05-categories-and-rules/05-DISCUSSION-LOG.md
@@ -1,0 +1,39 @@
+# Phase 5 Discussion Log
+
+**Date:** 2026-03-28
+**Phase:** 05-categories-and-rules
+
+## Discussed Areas
+
+### 1. Category Model
+- Chosen: top-level categories with optional subcategories
+- Kept the agreed built-in base category set
+- Income should ship with built-in subcategories
+- User-created categories can be top-level or nested under a parent
+
+### 2. Rule Model
+- Rules can match on description, amount range, transaction type, tags, and debit/credit direction
+- Rules can assign category/subcategory, type, and tags
+- Most specific matching user rule wins automatically
+- Ledger edits should save first, then offer a prefilled reusable-rule flow
+
+### 3. Categories and Rules UX
+- Categories and rules should share one screen with two side-by-side panes
+- User-created categories support create, rename, move, merge, activate/deactivate, and delete
+- Rules support create, edit, test, enable/disable, and delete
+- The screen should show how many transactions map to categories or are affected by rules
+
+### 4. Re-categorization Behavior
+- New rules apply to future transactions by default, with an optional apply-to-existing step
+- Editing a rule offers preview and optional re-apply to existing matches
+- Category merges migrate existing transactions immediately
+- Rule re-apply confirmation should show both a count and a sample list of affected transactions
+
+## Outcome
+
+Phase 5 context is now locked enough for UI design and planning.
+
+## Recommended Next Steps
+
+- `$gsd-ui-phase 5`
+- `$gsd-plan-phase 5`

--- a/.planning/phases/05-categories-and-rules/05-RESEARCH.md
+++ b/.planning/phases/05-categories-and-rules/05-RESEARCH.md
@@ -1,0 +1,386 @@
+# Phase 5 Research: Categories and Rules
+
+**Phase:** 05-categories-and-rules  
+**Date:** 2026-03-28  
+**Mode:** implementation / ecosystem  
+**Status:** Complete
+
+## Recommendation Summary
+
+Phase 5 should extend the existing SQLite-backed transaction model rather than introducing a parallel categorization service. The right implementation is:
+
+- store categories and rules in SQLite as first-class tables
+- keep system categories and user categories in the same table with explicit protection flags
+- model category hierarchy as a simple parent-child adjacency list
+- evaluate rules in the main process, not in the renderer
+- keep rule matching deterministic and explainable
+- preview rule re-apply impact before touching existing transactions
+- use repository-backed refetch-after-mutation, consistent with Phases 3 and 4
+
+This phase should not attempt a generalized automation engine. It should ship a narrow but strong local categorization system that future dashboard and audit phases can trust.
+
+## Standard Stack
+
+Use the repo’s existing stack and extend it:
+
+- **Persistence:** `better-sqlite3` with the existing repository layer in `src/main/persistence/db.ts`
+- **Validation and contracts:** `zod`
+- **Renderer:** `React 19` with the current Walnut shell patterns
+- **IPC boundary:** typed preload bridge in `src/preload/index.ts`
+- **Testing:** `vitest` for repository/renderer coverage and `playwright` for full end-to-end rule/category workflows
+
+For this phase, keep the implementation inside the current app architecture:
+
+- categories and rules are stored locally in SQLite
+- main process owns mutation and matching logic
+- renderer consumes typed query/result payloads and refetches authoritative state after mutations
+
+## Architecture Patterns
+
+### 1. Category hierarchy should use an adjacency-list table
+
+Use one categories table with:
+
+- `id`
+- `name`
+- `parent_id` nullable
+- `kind` or `is_system`
+- `is_income_category`
+- `is_active`
+- `sort_order`
+- timestamps
+
+Why:
+
+- it fits the chosen “top-level with optional subcategories” model cleanly
+- SQLite handles parent-child lookups well enough for this size of dataset
+- it keeps user-created and system categories in one queryable structure
+- it makes merge/move operations straightforward
+
+Do not create separate tables for system categories and user categories unless forced later. Phase 5 benefits from one tree with explicit protection flags.
+
+### 2. Rules should be row-based and deterministic
+
+Use one rules table plus a compiled/mapped in-memory evaluation pass in the main process.
+
+Suggested rule shape:
+
+- `id`
+- `name`
+- `is_enabled`
+- `scope` or `applies_to_existing_default`
+- `conditions_json`
+- `actions_json`
+- `specificity_score`
+- timestamps
+
+Conditions should represent the locked scope:
+
+- description match terms
+- amount min/max
+- normalized transaction type
+- tags
+- debit/credit direction
+
+Actions should represent the locked scope:
+
+- assign category
+- assign subcategory
+- assign normalized type
+- apply tags
+
+Evaluation order:
+
+1. collect matching enabled user rules
+2. compute specificity from the populated conditions
+3. choose the most specific
+4. if tied, use a stable deterministic fallback such as lower creation order or explicit stored order
+
+This keeps “most specific rule wins” explainable and testable.
+
+### 3. Keep category application and rule creation separate
+
+Phase 4 already introduced transaction editing and a rule-suggestion hook. Build on that without forcing the user into rule authoring.
+
+Recommended flow:
+
+- user edits transaction
+- transaction saves immediately
+- response includes optional “create rule from this change” suggestion payload
+- user opens a side flow with prefilled condition/action values
+- rule creation remains explicit
+
+This matches the user decision that ledger edits should save first, then offer a reusable rule side flow.
+
+### 4. Re-apply to existing transactions should use preview-first repository operations
+
+When creating or editing a rule:
+
+1. calculate affected transaction ids in the repository
+2. return a count plus a representative sample list
+3. ask for confirmation
+4. apply in one transaction
+5. refetch affected screen state
+
+This same pattern should power category merges:
+
+- resolve source category
+- calculate affected transaction count
+- migrate rows immediately to target category
+- return updated counts
+
+### 5. Rule testing should run against real local data, not static examples only
+
+The rule-management pane should support “test against matches” using the current transaction dataset.
+
+Recommended output:
+
+- number of matches
+- a small sample list
+- what action would be applied
+
+This is better than synthetic-only previews because the product is local-first and already owns the dataset.
+
+## Don't Hand-Roll
+
+### 1. Don’t build a second renderer-owned category/rule state model
+
+The repo already established a safer pattern in Phase 3 and Phase 4:
+
+- mutate in main process
+- refetch authoritative state
+
+Do not replace that with a complicated optimistic store for categories/rules.
+
+### 2. Don’t make precedence depend on vague heuristics alone
+
+The user explicitly chose “most specific rule wins automatically.”  
+That requires a stable, explainable scoring model.
+
+Do not ship a fuzzy priority model that changes unpredictably based on match order.
+
+### 3. Don’t hand-roll a generalized workflow engine
+
+Phase 5 needs deterministic category and rule application, not a scripting platform.  
+Avoid turning rules into arbitrary code or layered automations.
+
+Keep rules declarative and limited to the chosen match/action set.
+
+### 4. Don’t store category labels only where ids should exist
+
+Phase 4 currently exposes `category` as a label-shaped field. Phase 5 should shift toward durable category ids in persistence and contract payloads, even if the UI still shows labels.
+
+Using labels as the long-term relational key will make:
+
+- renames fragile
+- merges harder
+- dashboard joins error-prone
+
+### 5. Don’t make bulk re-apply opaque
+
+Any operation that changes existing transactions in bulk must preview impact first.  
+Do not silently re-apply edited rules to history.
+
+## Common Pitfalls
+
+### 1. Category renames vs merges get conflated
+
+They are not the same operation.
+
+- rename changes the label of one category
+- merge migrates transactions from one category id to another and then retires the source
+
+If these are implemented as the same operation, counts and later auditability get messy fast.
+
+### 2. System-category protection leaks into the UI only
+
+If protection exists only in the renderer, it will be bypassable or inconsistent.  
+Enforce “system categories are protected” in the repository layer too.
+
+### 3. Rules that write type and category can create surprising loops
+
+If a rule changes type, and type is also one of its matching conditions, careless re-evaluation can create inconsistent behavior.
+
+Recommendation:
+
+- evaluate against the pre-update row
+- apply one winning rule
+- do not recursively re-run rule evaluation inside the same operation
+
+### 4. Existing transaction counts become stale
+
+The Categories and Rules screen needs live counts.  
+If counts are stored separately without refresh strategy, they drift from reality.
+
+Prefer query-derived counts for Phase 5 unless profiling proves otherwise.
+
+### 5. Hierarchy moves can create cycles
+
+If user-created categories can move under parents, the repository must block:
+
+- moving a category under itself
+- moving a category under one of its descendants
+
+That validation belongs in the main process, not just the UI.
+
+## Suggested Data Model
+
+### Categories
+
+Use:
+
+- `categories`
+- `category_merge_history` only if needed later; Phase 5 can often get by without a dedicated history table
+
+Suggested columns:
+
+- `id`
+- `name`
+- `parent_id`
+- `is_system`
+- `is_active`
+- `is_income_category`
+- `sort_order`
+- `created_at`
+- `updated_at`
+
+Suggested transaction change:
+
+- add `category_id` to transactions
+- keep human-readable label mapping in query results
+
+### Rules
+
+Use:
+
+- `categorization_rules`
+
+Suggested columns:
+
+- `id`
+- `name`
+- `is_enabled`
+- `conditions_json`
+- `actions_json`
+- `specificity_score`
+- `created_at`
+- `updated_at`
+
+### Transaction integration
+
+Transactions should expose:
+
+- assigned `category_id`
+- derived category label path for UI
+- rule-origin metadata only if cheap to return; otherwise defer that to Phase 7 audit work
+
+## Suggested API Surface
+
+Add dedicated contracts instead of overloading transaction-only payloads.
+
+Recommended new operations:
+
+- `listCategories()`
+- `createCategory()`
+- `updateCategory()`
+- `mergeCategory()`
+- `deleteCategory()`
+- `listRules()`
+- `createRule()`
+- `updateRule()`
+- `deleteRule()`
+- `toggleRule()`
+- `testRule()`
+- `previewRuleApplyToExisting()`
+- `applyRuleToExisting()`
+- `suggestRuleFromTransactionEdit()`
+
+Keep category and rule payloads typed with `zod`, consistent with the existing contracts strategy.
+
+## Verification Guidance
+
+Repository coverage should emphasize:
+
+- protected system categories cannot be modified destructively
+- user-created categories support move, merge, deactivate, delete
+- rule specificity is deterministic
+- preview counts and samples for re-apply are correct
+- category merges migrate matching transactions correctly
+- rule application to existing rows updates the intended set only
+
+Renderer coverage should emphasize:
+
+- categories and rules render in side-by-side panes
+- counts update after mutations
+- rule test previews show a sample set
+- post-save rule suggestion flow from ledger edits is prefilled
+
+E2E coverage should emphasize:
+
+- create user category
+- assign or merge category
+- create rule from transaction edit
+- preview and apply to existing
+- verify updated transaction list results
+
+## Code Examples
+
+### Example: specificity scoring
+
+Use a simple weighted score based on populated conditions.
+
+Pseudo-approach:
+
+```ts
+const scoreRuleSpecificity = (rule: RuleConditions) =>
+  [
+    rule.descriptionTerms?.length ? 4 : 0,
+    rule.amountMinMinor !== undefined || rule.amountMaxMinor !== undefined ? 3 : 0,
+    rule.normalizedType ? 2 : 0,
+    rule.direction ? 2 : 0,
+    rule.tags?.length ? 1 : 0
+  ].reduce((sum, part) => sum + part, 0)
+```
+
+Then sort by:
+
+1. score descending
+2. explicit stable fallback such as `created_at ASC`
+
+### Example: preview before apply
+
+```ts
+const matchingRows = repository.listTransactions(buildRuleQuery(rule))
+return {
+  matchCount: matchingRows.length,
+  samples: matchingRows.slice(0, 10)
+}
+```
+
+Only apply after explicit confirmation.
+
+### Example: category protection check
+
+```ts
+if (category.isSystem && destructiveActionRequested) {
+  throw new Error('System categories are protected and cannot be deleted or merged into a user edit flow.')
+}
+```
+
+## Confidence
+
+- **High:** extending the existing SQLite + preload + renderer pattern is the correct architecture for this phase
+- **High:** adjacency-list categories are sufficient and preferable for the current hierarchy scope
+- **High:** declarative, repository-owned rule evaluation is the right fit for the chosen requirements
+- **Medium:** exact specificity weighting should be refined during planning and verified with real data
+
+## Bottom Line
+
+Phase 5 should be built as a repository-backed local taxonomy and rule system, not as a UI-only categorization layer and not as a general automation engine. The best path is:
+
+- categories as a protected hierarchical SQLite model
+- rules as declarative rows with deterministic specificity
+- preview-first bulk apply behavior
+- strong reuse of the Phase 4 transaction editing and suggestion seams
+
+That gives Phase 6 and Phase 7 a stable base without overbuilding Phase 5.

--- a/.planning/phases/05-categories-and-rules/05-UI-SPEC.md
+++ b/.planning/phases/05-categories-and-rules/05-UI-SPEC.md
@@ -1,0 +1,206 @@
+---
+phase: 05
+slug: categories-and-rules
+status: approved
+shadcn_initialized: false
+preset: none
+created: 2026-03-28
+reviewed_at: 2026-03-28
+---
+
+# Phase 05 - UI Design Contract
+
+> Visual and interaction contract for frontend phases. Generated from locked Phase 5 decisions and approved for planning.
+
+---
+
+## Design System
+
+| Property | Value |
+|----------|-------|
+| Tool | none |
+| Preset | not applicable |
+| Component library | none |
+| Icon library | lucide |
+| Font | Manrope |
+
+Manual token contract inherited from `src/renderer/styles/tokens.css`. Preserve the current React + Vite renderer, inline style composition, token names, and light/dark theme behavior. Do not introduce shadcn, Tailwind, or a second component system in this phase.
+
+---
+
+## Categories and Rules Workspace Contract
+
+### Primary Screen
+- Add one dedicated `Categories & Rules` destination to the existing left rail.
+- Keep the workspace inside the current Walnut shell, not in settings and not in detached modal-only flows.
+- The primary visual anchor is the dual-pane operational workspace: categories on one side, rules on the other.
+- The page should feel like a finance control surface, not a generic admin table.
+
+### Categories Pane
+- The categories pane should present a protected system taxonomy plus user-created categories in one hierarchy.
+- Top-level categories and optional subcategories should be visually distinct through indentation and hierarchy cues, not separate screens.
+- Built-in system categories must always read as protected and stable.
+- User-created categories must clearly expose their editable/manageable state.
+- Each category row should show:
+  - category name
+  - parent context when relevant
+  - active/inactive state
+  - mapped transaction count
+- Income categories should appear inside the same taxonomy and visibly support subcategories.
+
+### Rules Pane
+- The rules pane should act as a deterministic automation list, not a hidden background system.
+- Each rule row should show:
+  - rule name
+  - enabled/disabled state
+  - a short readable summary of match conditions
+  - a short readable summary of actions
+  - affected transaction count
+- Most-specific-wins precedence should be explainable in rule detail and test preview language.
+- Rules should remain declarative and readable; do not present them like scripts.
+
+### Split-Pane Behavior
+- Categories and rules should remain visible side-by-side on standard desktop widths.
+- On narrower widths, the layout may stack, but it must preserve clear return paths and pane identity.
+- The focused pane should have stronger visual priority, while the secondary pane remains legible and contextual.
+- Destructive or trust-sensitive actions should never replace the whole screen with blocking modal flows unless absolutely necessary.
+
+### Edit and Create Surfaces
+- Category creation and editing should open in a focused side panel or embedded detail area rather than navigating away.
+- Rule creation from a transaction edit should open as a prefilled side flow that keeps the user grounded in the current context.
+- Editing a rule should expose:
+  - match conditions
+  - resulting category/type/tag actions
+  - enable/disable state
+  - test-preview action
+- Category merge and rule re-apply actions must surface impact preview before commit.
+
+### Preview and Re-apply
+- Any “apply to existing transactions” workflow must show:
+  - affected count
+  - a sample transaction list
+  - a clear action summary
+- The preview should feel confirmatory and trust-building, not like a bulk data mystery.
+- Sample lists should be concise and scan-friendly, with the option to proceed or cancel without losing current context.
+
+### Visual Focal Points
+- In the categories pane, the eye should land first on the hierarchy header and transaction counts so users immediately understand scope.
+- In the rules pane, the eye should land first on enabled rule summaries and affected counts so the impact of automation is legible at a glance.
+
+---
+
+## State and Feedback Contract
+
+- Protected system categories must visually read as protected before a user attempts an action.
+- User-created categories must visually read as flexible and manageable.
+- Rule changes should feel deterministic and locally applied, not eventually consistent.
+- Testing a rule should show a concise preview state rather than a passive success message only.
+- Apply-to-existing confirmations must make impact obvious before committing changes.
+- Category merges should confirm destination and affected transaction count before running.
+- Error copy must explain that the operation was not applied and current category/rule state remains unchanged.
+- Success feedback should confirm local completion without relying only on toasts.
+
+### Empty States
+- Categories empty state heading: `No custom categories yet`
+- Categories empty state body: `System categories are ready. Add a custom category when the built-in taxonomy is not enough for your household.`
+- Rules empty state heading: `No rules yet`
+- Rules empty state body: `Use ledger corrections or create a rule here to start automating recurring category and type decisions.`
+- Preview empty state heading: `No matching transactions`
+- Preview empty state body: `This rule does not affect any current transactions with the chosen conditions.`
+
+### Keyboard Contract
+- `Tab` and `Shift+Tab` traverse category rows, rule rows, create actions, preview actions, and side-panel form fields in visual order.
+- `Enter` on a focused category or rule row opens its detail/edit surface.
+- `Esc` closes the active side panel or preview surface without leaving the Categories & Rules workspace.
+- Hierarchy rows, enable/disable toggles, and test-preview actions must be fully keyboard reachable.
+
+---
+
+## Component Inventory
+
+- `Categories and Rules workspace header`
+- `Categories hierarchy pane`
+- `Category row`
+- `Protected category badge`
+- `User category row actions`
+- `Rules list pane`
+- `Rule row`
+- `Rule match summary`
+- `Rule action summary`
+- `Category detail side panel`
+- `Rule detail side panel`
+- `Rule preview panel`
+- `Apply-to-existing confirmation surface`
+
+Use the established Walnut surface language: large rounded cards, restrained accent emphasis, readable density, and clear scan order over decorative noise.
+
+---
+
+## Spacing Scale
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| xs | 4px | Badge gaps, inline hierarchy markers |
+| sm | 8px | Compact metadata, chip spacing |
+| md | 16px | Default row spacing, form fields, pane rhythm |
+| lg | 24px | Card padding, pane padding, section separation |
+| xl | 32px | Main layout gutters and major workspace separation |
+| 2xl | 48px | Large region breathing room |
+
+---
+
+## Typography
+
+| Role | Size | Weight | Line Height |
+|------|------|--------|-------------|
+| Body | 16px | 400 | 1.5 |
+| Label | 14px | 600 | 1.4 |
+| Heading | 20px | 600 | 1.2 |
+| Display | 32px | 600 | 1.1 |
+
+Use sentence case throughout. Reserve display size for the top-level page heading only.
+
+---
+
+## Color
+
+| Role | Value | Usage |
+|------|-------|-------|
+| Dominant (60%) | #F5F1E8 | Page background, main workspace canvas |
+| Secondary (30%) | #E2D7C5 | Pane surfaces, side panels, preview cards |
+| Accent (10%) | #0F766E | Active controls, selected rows, primary actions, enabled-rule emphasis |
+| Destructive | #B42318 | Merge/delete warnings, failed apply messaging, irreversible confirmations |
+
+Keep the current Walnut palette and avoid introducing new semantic accent families beyond the existing token vocabulary.
+
+---
+
+## Copywriting Contract
+
+| Element | Copy |
+|---------|------|
+| Categories pane heading | Categories |
+| Rules pane heading | Rules |
+| Categories empty state heading | No custom categories yet |
+| Rules empty state heading | No rules yet |
+| Apply preview heading | Review affected transactions |
+| Error state | This change was not applied. Review the current configuration, adjust the inputs, and try again. |
+
+Microcopy rules:
+- Lead with clarity and trust, not automation hype.
+- Prefer `match`, `apply`, `preview`, `affected`, `protected`, and `local`.
+- Avoid `smart`, `magic`, `auto-fix`, or language that implies hidden behavior.
+- Rule precedence language must be explainable and plain.
+
+---
+
+## Checker Sign-Off
+
+- [x] Dimension 1 Copywriting: PASS
+- [x] Dimension 2 Visuals: PASS
+- [x] Dimension 3 Color: PASS
+- [x] Dimension 4 Typography: PASS
+- [x] Dimension 5 Spacing: PASS
+- [x] Dimension 6 Registry Safety: PASS
+
+**Approval:** approved

--- a/.planning/phases/05-categories-and-rules/05-VALIDATION.md
+++ b/.planning/phases/05-categories-and-rules/05-VALIDATION.md
@@ -1,0 +1,80 @@
+---
+phase: 05
+slug: categories-and-rules
+status: draft
+nyquist_compliant: true
+wave_0_complete: false
+created: 2026-03-28
+---
+
+# Phase 05 - Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | Vitest 3.2.4 + Playwright 1.55.0 |
+| **Config file** | `vitest.config.ts`, `playwright.config.ts` |
+| **Quick run command** | `cmd /c npx vitest run tests/unit/categories/*.test.ts tests/unit/categories-rules-screen.test.tsx` |
+| **Full suite command** | `cmd /c npm run test:unit` and `cmd /c npx playwright test tests/e2e/categories-rules.spec.ts` |
+| **Estimated runtime** | ~95 seconds |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run the task-local Vitest command declared in the active plan.
+- **After every plan wave:** Run `cmd /c npm run test:unit`
+- **Before `$gsd-verify-work`:** Full unit suite plus `cmd /c npx playwright test tests/e2e/categories-rules.spec.ts`
+- **Max feedback latency:** 90 seconds
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|-----------|-------------------|-------------|--------|
+| 05-01-01 | 01 | 1 | CATR-02, CATR-05, CATR-06 | unit | `cmd /c npx vitest run tests/unit/categories/category-repository.test.ts tests/unit/categories/rule-engine.test.ts` | No - W0 | pending |
+| 05-01-02 | 01 | 1 | CATR-01, CATR-04 | unit | `cmd /c npx vitest run tests/unit/categories/category-repository.test.ts tests/unit/categories/rule-engine.test.ts` | No - W0 | pending |
+| 05-02-01 | 02 | 2 | CATR-01, CATR-03, CATR-06 | unit | `cmd /c npx vitest run tests/unit/categories/rule-engine.test.ts tests/unit/categories/rule-preview.test.ts` | No - W0 | pending |
+| 05-02-02 | 02 | 2 | CATR-03 | unit + component | `cmd /c npx vitest run tests/unit/categories/rule-preview.test.ts tests/unit/transactions/rule-suggestion.test.tsx` | No - W0 | pending |
+| 05-03-01 | 03 | 3 | CATR-04, CATR-05 | component | `cmd /c npx vitest run tests/unit/categories-rules-screen.test.tsx` | No - W0 | pending |
+| 05-03-02 | 03 | 3 | CATR-01, CATR-03, CATR-06 | component | `cmd /c npx vitest run tests/unit/categories-rules-screen.test.tsx tests/unit/transactions/rule-suggestion.test.tsx` | No - W0 | pending |
+| 05-04-01 | 04 | 4 | CATR-01, CATR-02, CATR-03, CATR-04, CATR-05, CATR-06 | unit + e2e | `cmd /c npx vitest run tests/unit/categories/*.test.ts tests/unit/categories-rules-screen.test.tsx tests/unit/transactions/rule-suggestion.test.tsx && cmd /c npx playwright test tests/e2e/categories-rules.spec.ts` | No - W0 | pending |
+
+---
+
+## Wave 0 Requirements
+
+- [ ] `tests/unit/categories/category-repository.test.ts` - system taxonomy seeding, user-category CRUD, move, merge, activate/deactivate, and system protection coverage
+- [ ] `tests/unit/categories/rule-engine.test.ts` - deterministic specificity scoring, starter-rule application, and future-vs-previewed apply behavior
+- [ ] `tests/unit/categories/rule-preview.test.ts` - apply-to-existing previews with count and sample transaction results
+- [ ] `tests/unit/categories-rules-screen.test.tsx` - dual-pane Categories & Rules workspace rendering, counts, side-panel flows, and preview surfaces
+- [ ] `tests/unit/transactions/rule-suggestion.test.tsx` - post-save rule suggestion flow from the transaction drawer with prefilled values
+- [ ] `tests/e2e/categories-rules.spec.ts` - create category, create/test rule, preview apply-to-existing, and verify transaction categorization changes
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| Protected system categories feel obviously protected while user categories still feel flexible | CATR-04, CATR-05 | Visual trust cues and edit affordances are easier to judge interactively | Open the Categories & Rules workspace in light and dark themes and verify system rows read as protected while user rows expose clear actions |
+| Rule preview language makes bulk re-categorization impact easy to understand | CATR-03 | Preview clarity and transaction-sample readability are best judged by a human | Create or edit a rule, open the apply-to-existing preview, and confirm the count plus sample list clearly explain what will change |
+
+---
+
+## Validation Sign-Off
+
+- [x] All tasks have `<automated>` verification commands
+- [x] Sampling continuity is preserved across waves
+- [x] Wave 0 gaps are explicitly listed
+- [x] No watch-mode commands are used
+- [x] Feedback latency stays under the phase target
+- [x] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** ready

--- a/.planning/phases/05-categories-and-rules/05-VERIFICATION.md
+++ b/.planning/phases/05-categories-and-rules/05-VERIFICATION.md
@@ -1,0 +1,18 @@
+# Phase 5 Verification
+
+Phase 5 verification passed on 2026-03-28.
+
+Commands run:
+- `cmd /c npm run test:unit`
+- `cmd /c npm run test:e2e`
+- `cmd /c npm run build`
+
+Verified outcomes:
+- Walnut seeds the protected starter taxonomy, including income subcategories, in the local repository
+- User-created categories can be created, moved, merged, activated/deactivated, and deleted without allowing CRUD on system categories
+- Rules can match on description, amount range, type, tags, and debit/credit direction and resolve by specificity
+- Rule previews show count/sample impact before applying to existing transactions
+- Ledger edits can hand off a prefilled reusable rule draft into the Categories & Rules workspace
+- The dedicated Categories & Rules workspace supports local category/rule management and preview-first automation flows
+- Category and rule side panels remain usable in shorter window heights
+- Production build still succeeds after the Phase 5 backend and renderer changes

--- a/docs/DELIVERY.md
+++ b/docs/DELIVERY.md
@@ -47,7 +47,7 @@ Each epic should include:
 
 Create stories only for phases that already have `*-PLAN.md` files.
 
-At the moment, Phase 1, Phase 2, Phase 3, and Phase 4 have plan files, so the active story set is:
+At the moment, Phase 1, Phase 2, Phase 3, Phase 4, and Phase 5 have plan files, so the active story set is:
 
 - Phase 1 / Wave 1
 - Phase 1 / Wave 2
@@ -63,6 +63,10 @@ At the moment, Phase 1, Phase 2, Phase 3, and Phase 4 have plan files, so the ac
 - Phase 4 / Wave 2
 - Phase 4 / Wave 3
 - Phase 4 / Wave 4
+- Phase 5 / Wave 1
+- Phase 5 / Wave 2
+- Phase 5 / Wave 3
+- Phase 5 / Wave 4
 
 ## Phase 1 Story Breakdown
 
@@ -250,6 +254,60 @@ Plan reference:
 
 - `.planning/phases/04-transaction-ledger-and-search/04-04-PLAN.md`
 
+## Phase 5 Story Breakdown
+
+### Wave 1 Story
+
+Scope:
+
+- protected taxonomy foundation
+- durable category ids
+- category-to-transaction linkage
+- safe user-category management
+
+Plan reference:
+
+- `.planning/phases/05-categories-and-rules/05-01-PLAN.md`
+
+### Wave 2 Story
+
+Scope:
+
+- deterministic rule engine
+- specificity resolution
+- preview-first apply flows
+- transaction rule-suggestion handoff
+
+Plan reference:
+
+- `.planning/phases/05-categories-and-rules/05-02-PLAN.md`
+
+### Wave 3 Story
+
+Scope:
+
+- Categories & Rules workspace
+- category/rule side panels
+- preview surface
+- dual-pane management UX
+
+Plan reference:
+
+- `.planning/phases/05-categories-and-rules/05-03-PLAN.md`
+
+### Wave 4 Story
+
+Scope:
+
+- repository tests
+- renderer tests
+- browser automation coverage
+- verification handoff
+
+Plan reference:
+
+- `.planning/phases/05-categories-and-rules/05-04-PLAN.md`
+
 ## Completion Workflow
 
 When a phase completes:
@@ -272,7 +330,9 @@ When a phase completes:
 - Phase 4 tracking items are epic `#4` and stories `#29`, `#30`, `#31`, and `#32`
 - The current Phase 4 branch also carries the active shell and ledger polish follow-through
 - That polish scope now includes multi-profile local selection on the lock screen, a dedicated new-profile flow, responsive lock-screen behavior, cleaner import workspace hierarchy, and updated ledger summaries/search/pagination coverage
-- Next discussion track is Phase 5: Categories and Rules
+- Phase 5 implementation is complete on `phase/5-categories-and-rules`
+- Phase 5 tracking items are epic `#5` and stories `#35`, `#36`, `#37`, and `#39`
+- Next discussion track is Phase 6: Dashboard Analytics
 
 ## Documentation Expectations
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -35,6 +35,7 @@ Status: completed on `phase/4-transaction-ledger-and-search`.
 ### Phase 5: Categories and Rules
 
 Goal: provide strong categorization defaults while keeping user control over rules and custom categories.
+Status: completed on `phase/5-categories-and-rules`.
 
 ### Phase 6: Dashboard Analytics
 
@@ -152,6 +153,25 @@ Follow-through polish shipped on the same branch:
 - dedicated create-new-profile screen
 - import-workspace layout cleanup
 - full-width ledger refinements, summary totals, pagination, explicit description search, and filtered difference totals
+
+## Phase 5 Completed Waves
+
+Phase 5 was decomposed into four execution waves and is now implemented:
+
+- Wave 1: protected taxonomy foundation, durable category ids, and safe category management
+- Wave 2: deterministic rule engine, preview-first bulk apply flows, and transaction rule-suggestion handoff
+- Wave 3: dual-pane Categories & Rules workspace with side-panel editors and previews
+- Wave 4: repository, renderer, and browser verification coverage
+
+Execution artifacts:
+
+- `.planning/phases/05-categories-and-rules/05-01-SUMMARY.md`
+- `.planning/phases/05-categories-and-rules/05-02-SUMMARY.md`
+- `.planning/phases/05-categories-and-rules/05-03-SUMMARY.md`
+- `.planning/phases/05-categories-and-rules/05-04-SUMMARY.md`
+- `.planning/phases/05-categories-and-rules/05-VERIFICATION.md`
+- GitHub epic `#5`
+- GitHub stories `#35`, `#36`, `#37`, and `#39`
 
 ## Active Enhancement Branches
 

--- a/src/main/ipc/categories.ts
+++ b/src/main/ipc/categories.ts
@@ -1,0 +1,35 @@
+import { ipcMain } from 'electron'
+import type {
+  ApplyRuleToExistingInput,
+  CreateCategoryInput,
+  CreateCategorizationRuleInput,
+  DeleteCategoryInput,
+  DeleteCategorizationRuleInput,
+  MergeCategoryInput,
+  RulePreviewInput,
+  ToggleCategorizationRuleInput,
+  UpdateCategoryInput,
+  UpdateCategorizationRuleInput
+} from '../../shared/contracts/categories'
+import { getWalnutRepository } from '../persistence/db'
+
+export const registerCategoriesIpc = () => {
+  const repository = getWalnutRepository()
+
+  ipcMain.handle('categories:list', () => repository.listCategories())
+  ipcMain.handle('categories:create', (_event, input: CreateCategoryInput) => repository.createCategory(input))
+  ipcMain.handle('categories:update', (_event, input: UpdateCategoryInput) => repository.updateCategory(input))
+  ipcMain.handle('categories:merge', (_event, input: MergeCategoryInput) => repository.mergeCategory(input))
+  ipcMain.handle('categories:delete', (_event, input: DeleteCategoryInput) => repository.deleteCategory(input))
+
+  ipcMain.handle('rules:list', () => repository.listRules())
+  ipcMain.handle('rules:create', (_event, input: CreateCategorizationRuleInput) => repository.createRule(input))
+  ipcMain.handle('rules:update', (_event, input: UpdateCategorizationRuleInput) => repository.updateRule(input))
+  ipcMain.handle('rules:toggle', (_event, input: ToggleCategorizationRuleInput) => repository.toggleRule(input))
+  ipcMain.handle('rules:delete', (_event, input: DeleteCategorizationRuleInput) => repository.deleteRule(input))
+  ipcMain.handle('rules:test', (_event, input: RulePreviewInput) => repository.testRule(input))
+  ipcMain.handle('rules:preview-apply', (_event, input: RulePreviewInput | ApplyRuleToExistingInput) =>
+    repository.previewRuleApplyToExisting(input)
+  )
+  ipcMain.handle('rules:apply', (_event, input: ApplyRuleToExistingInput) => repository.applyRuleToExisting(input))
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, shell } from 'electron'
 import { join } from 'node:path'
 import { registerAppStateIpc } from './ipc/app-state'
+import { registerCategoriesIpc } from './ipc/categories'
 import { registerImportIpc } from './ipc/import'
 import { registerTransactionsIpc } from './ipc/transactions'
 import { registerSecurityIpc } from './ipc/security'
@@ -28,6 +29,7 @@ const createWindow = async () => {
 
   const sessionLock = new SessionLockManager()
   registerAppStateIpc()
+  registerCategoriesIpc()
   registerImportIpc(mainWindow)
   registerTransactionsIpc()
   registerSecurityIpc(mainWindow, sessionLock)

--- a/src/main/persistence/db.ts
+++ b/src/main/persistence/db.ts
@@ -12,6 +12,26 @@ import type {
 } from '../../shared/contracts/app-state'
 import type { AccountProfile, AccountProfileDraft } from '../../shared/contracts/account'
 import type {
+  ApplyRuleToExistingInput,
+  CategoryDirection,
+  CategoryTreeNode,
+  CategorizationRuleAction,
+  CategorizationRuleCondition,
+  CategorizationRuleSummary,
+  CreateCategoryInput,
+  CreateCategorizationRuleInput,
+  DeleteCategoryInput,
+  DeleteCategorizationRuleInput,
+  MergeCategoryInput,
+  RuleApplyPreview,
+  RulePreviewInput,
+  RulePreviewSample,
+  RuleTestPreview,
+  ToggleCategorizationRuleInput,
+  UpdateCategoryInput,
+  UpdateCategorizationRuleInput
+} from '../../shared/contracts/categories'
+import type {
   CommitImportBatchResult,
   GetImportBatchDetailInput,
   GetReviewQueueInput,
@@ -65,6 +85,114 @@ const defaultSecurityState: SecurityState = {
 const nowIso = () => new Date().toISOString()
 const singleRowId = 1
 
+interface SeedCategoryDefinition {
+  id: string
+  name: string
+  parentId?: string
+  isIncomeCategory?: boolean
+  sortOrder: number
+}
+
+const categoryId = (slug: string) => `cat:${slug}`
+const ruleId = (slug: string) => `rule:${slug}`
+
+const systemCategorySeeds: SeedCategoryDefinition[] = [
+  { id: categoryId('food-dining'), name: 'Food & Dining', sortOrder: 10 },
+  { id: categoryId('groceries'), name: 'Groceries', sortOrder: 20 },
+  { id: categoryId('shopping'), name: 'Shopping', sortOrder: 30 },
+  { id: categoryId('bills-utilities'), name: 'Bills & Utilities', sortOrder: 40 },
+  { id: categoryId('rent-housing'), name: 'Rent / Housing', sortOrder: 50 },
+  { id: categoryId('transport'), name: 'Transport', sortOrder: 60 },
+  { id: categoryId('travel'), name: 'Travel', sortOrder: 70 },
+  { id: categoryId('healthcare'), name: 'Healthcare', sortOrder: 80 },
+  { id: categoryId('entertainment'), name: 'Entertainment', sortOrder: 90 },
+  { id: categoryId('education'), name: 'Education', sortOrder: 100 },
+  { id: categoryId('insurance'), name: 'Insurance', sortOrder: 110 },
+  { id: categoryId('taxes-fees'), name: 'Taxes & Fees', sortOrder: 120 },
+  { id: categoryId('cash-atm'), name: 'Cash / ATM', sortOrder: 130 },
+  { id: categoryId('transfers'), name: 'Transfers', sortOrder: 140 },
+  { id: categoryId('credit-card-payment'), name: 'Credit Card Payment', sortOrder: 150 },
+  { id: categoryId('income'), name: 'Income', sortOrder: 160, isIncomeCategory: true },
+  { id: categoryId('refunds-reimbursements'), name: 'Refunds / Reimbursements', sortOrder: 170, isIncomeCategory: true },
+  { id: categoryId('investments-savings'), name: 'Investments / Savings', sortOrder: 180 },
+  { id: categoryId('uncategorized'), name: 'Uncategorized', sortOrder: 190 },
+  { id: categoryId('income-salary'), name: 'Salary', parentId: categoryId('income'), sortOrder: 161, isIncomeCategory: true },
+  { id: categoryId('income-business'), name: 'Business Income', parentId: categoryId('income'), sortOrder: 162, isIncomeCategory: true },
+  { id: categoryId('income-interest'), name: 'Interest', parentId: categoryId('income'), sortOrder: 163, isIncomeCategory: true },
+  {
+    id: categoryId('income-refund-reimbursement'),
+    name: 'Refund / Reimbursement Income',
+    parentId: categoryId('income'),
+    sortOrder: 164,
+    isIncomeCategory: true
+  },
+  {
+    id: categoryId('income-investment'),
+    name: 'Investment Income',
+    parentId: categoryId('income'),
+    sortOrder: 165,
+    isIncomeCategory: true
+  },
+  { id: categoryId('income-other'), name: 'Other Income', parentId: categoryId('income'), sortOrder: 166, isIncomeCategory: true }
+]
+
+const starterRuleSeeds: Array<{
+  id: string
+  name: string
+  condition: CategorizationRuleCondition
+  action: CategorizationRuleAction
+  sortOrder: number
+}> = [
+  {
+    id: ruleId('salary-credit'),
+    name: 'Salary credit',
+    condition: {
+      descriptionContains: ['salary'],
+      transactionTypes: ['income'],
+      tags: [],
+      directions: ['credit']
+    },
+    action: {
+      categoryId: categoryId('income-salary'),
+      type: 'income',
+      appendTags: ['salary']
+    },
+    sortOrder: 10
+  },
+  {
+    id: ruleId('atm-withdrawal'),
+    name: 'ATM withdrawal',
+    condition: {
+      descriptionContains: ['atm'],
+      transactionTypes: ['atm-withdrawal'],
+      tags: [],
+      directions: ['debit']
+    },
+    action: {
+      categoryId: categoryId('cash-atm'),
+      type: 'atm-withdrawal',
+      appendTags: ['cash']
+    },
+    sortOrder: 20
+  },
+  {
+    id: ruleId('credit-card-payment'),
+    name: 'Credit card payment',
+    condition: {
+      descriptionContains: ['card payment'],
+      transactionTypes: ['credit-card-payment'],
+      tags: [],
+      directions: ['debit']
+    },
+    action: {
+      categoryId: categoryId('credit-card-payment'),
+      type: 'credit-card-payment',
+      appendTags: []
+    },
+    sortOrder: 30
+  }
+]
+
 const toSortableDateKey = (raw: string) => {
   const trimmed = raw.trim()
   const isoMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed)
@@ -95,6 +223,19 @@ const getSignedAmountMinor = (row: {
 
   return -Math.abs(Number(debit ?? 0))
 }
+
+const extractRuleKeywords = (description: string) =>
+  description
+    .split(/[\s/:-]+/)
+    .map((token) => token.trim().toLowerCase())
+    .filter((token) => token.length >= 3)
+    .slice(0, 3)
+
+const detailDescriptionToRuleName = (description: string) =>
+  description
+    .trim()
+    .replace(/\s+/g, ' ')
+    .slice(0, 40)
 
 const deriveNormalizedType = (row: {
   cleanedDescription: string
@@ -340,11 +481,37 @@ export class WalnutRepository {
         running_balance_minor INTEGER,
         direction TEXT NOT NULL,
         normalized_type TEXT,
+        category_id TEXT,
         category_label TEXT,
         review_state_override TEXT,
         reference TEXT,
         transaction_signature TEXT NOT NULL,
         tags_json TEXT
+      );
+      CREATE TABLE IF NOT EXISTS categories (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        parent_id TEXT,
+        kind TEXT NOT NULL,
+        is_system INTEGER NOT NULL DEFAULT 0,
+        is_income_category INTEGER NOT NULL DEFAULT 0,
+        is_active INTEGER NOT NULL DEFAULT 1,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS categorization_rules (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        is_system INTEGER NOT NULL DEFAULT 0,
+        is_enabled INTEGER NOT NULL DEFAULT 1,
+        condition_json TEXT NOT NULL,
+        action_json TEXT NOT NULL,
+        specificity_score INTEGER NOT NULL DEFAULT 0,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
       );
       CREATE TABLE IF NOT EXISTS review_items (
         id TEXT PRIMARY KEY,
@@ -368,6 +535,10 @@ export class WalnutRepository {
         ON import_attempts(status, imported_at DESC);
       CREATE INDEX IF NOT EXISTS idx_import_attempts_batch_id
         ON import_attempts(batch_id);
+      CREATE INDEX IF NOT EXISTS idx_categories_parent_sort
+        ON categories(parent_id, sort_order);
+      CREATE INDEX IF NOT EXISTS idx_categorization_rules_enabled
+        ON categorization_rules(is_enabled, kind, specificity_score DESC, sort_order ASC);
       CREATE INDEX IF NOT EXISTS idx_review_items_batch_state
         ON review_items(batch_id, state);
       CREATE INDEX IF NOT EXISTS idx_review_items_attempt_id
@@ -377,8 +548,10 @@ export class WalnutRepository {
     this.ensureColumn('imported_transactions', 'tags_json', 'TEXT')
     this.ensureColumn('imported_transactions', 'transaction_date_sortable', 'TEXT')
     this.ensureColumn('imported_transactions', 'normalized_type', 'TEXT')
+    this.ensureColumn('imported_transactions', 'category_id', 'TEXT')
     this.ensureColumn('imported_transactions', 'category_label', 'TEXT')
     this.ensureColumn('imported_transactions', 'review_state_override', 'TEXT')
+    this.ensureColumn('categorization_rules', 'sort_order', 'INTEGER NOT NULL DEFAULT 0')
     this.ensureColumn('review_items', 'resolution_action', 'TEXT')
     this.ensureColumn('review_items', 'resolution_payload_json', 'TEXT')
     this.ensureColumn('review_items', 'resolved_at', 'TEXT')
@@ -399,6 +572,9 @@ export class WalnutRepository {
         VALUES (?, ?, ?, ?)`
       )
       .run(singleRowId, 0, 0, stamp)
+
+    this.seedSystemCategories(stamp)
+    this.seedStarterRules(stamp)
   }
 
   private ensureColumn(tableName: string, columnName: string, definition: string) {
@@ -411,6 +587,53 @@ export class WalnutRepository {
     }
 
     this.sqlite.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${definition};`)
+  }
+
+  private seedSystemCategories(stamp: string) {
+    const insertCategory = this.sqlite.prepare(
+      `INSERT OR IGNORE INTO categories
+       (id, name, parent_id, kind, is_system, is_income_category, is_active, sort_order, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+
+    for (const seed of systemCategorySeeds) {
+      insertCategory.run(
+        seed.id,
+        seed.name,
+        seed.parentId ?? null,
+        'system',
+        1,
+        seed.isIncomeCategory ? 1 : 0,
+        1,
+        seed.sortOrder,
+        stamp,
+        stamp
+      )
+    }
+  }
+
+  private seedStarterRules(stamp: string) {
+    const insertRule = this.sqlite.prepare(
+      `INSERT OR IGNORE INTO categorization_rules
+       (id, name, kind, is_system, is_enabled, condition_json, action_json, specificity_score, sort_order, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+
+    for (const seed of starterRuleSeeds) {
+      insertRule.run(
+        seed.id,
+        seed.name,
+        'system',
+        1,
+        1,
+        JSON.stringify(seed.condition),
+        JSON.stringify(seed.action),
+        this.computeRuleSpecificity(seed.condition),
+        seed.sortOrder,
+        stamp,
+        stamp
+      )
+    }
   }
 
   private getAppSetting(key: string) {
@@ -723,8 +946,8 @@ export class WalnutRepository {
     const insertImportedTransaction = this.sqlite.prepare(
       `INSERT INTO imported_transactions
        (id, import_batch_id, source_file_id, transaction_date_raw, transaction_date_sortable, value_date_raw, raw_narration, cleaned_description,
-        debit_amount_minor, credit_amount_minor, running_balance_minor, direction, normalized_type, category_label, review_state_override, reference, transaction_signature, tags_json)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        debit_amount_minor, credit_amount_minor, running_balance_minor, direction, normalized_type, category_id, category_label, review_state_override, reference, transaction_signature, tags_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     for (const row of snapshot.importedTransactions) {
       insertImportedTransaction.run(
@@ -746,6 +969,7 @@ export class WalnutRepository {
           reference: row.reference ? String(row.reference) : undefined,
           direction: String(row.direction) as 'debit' | 'credit'
         }),
+        row.category_id ?? null,
         row.category_label ?? null,
         row.review_state_override ?? null,
         row.reference ?? null,
@@ -1201,7 +1425,13 @@ export class WalnutRepository {
 
         if (query.categories?.length) {
           const normalizedCategories = query.categories.map((category) => category.toLowerCase())
-          if (!row.category || !normalizedCategories.includes(row.category.toLowerCase())) {
+          const categoryValues = [
+            row.categoryId?.toLowerCase(),
+            row.category?.toLowerCase(),
+            ...(row.categoryPath ?? []).map((segment) => segment.toLowerCase())
+          ].filter(Boolean)
+
+          if (!normalizedCategories.some((category) => categoryValues.includes(category))) {
             return false
           }
         }
@@ -1264,7 +1494,12 @@ export class WalnutRepository {
     const nextDebitAmountMinor = nextDirection === 'debit' ? Math.abs(nextSignedAmountMinor) : null
     const nextCreditAmountMinor = nextDirection === 'credit' ? Math.abs(nextSignedAmountMinor) : null
     const nextNormalizedType = input.normalizedType ?? current.normalizedType
-    const nextCategory = input.category === undefined ? current.category ?? null : input.category
+    const nextCategoryId =
+      input.categoryId === undefined
+        ? current.categoryId ?? null
+        : input.categoryId
+    const nextCategoryPath = this.getCategoryPathById(nextCategoryId)
+    const nextCategory = input.category === undefined ? (nextCategoryPath.length ? nextCategoryPath.join(' > ') : current.category ?? null) : input.category
     const nextReference = input.reference === undefined ? current.reference ?? null : input.reference
     const nextTags = input.tags ?? current.tags
     const nextReviewStateOverride =
@@ -1280,6 +1515,7 @@ export class WalnutRepository {
              credit_amount_minor = ?,
              direction = ?,
              normalized_type = ?,
+             category_id = ?,
              category_label = ?,
              reference = ?,
              tags_json = ?,
@@ -1294,6 +1530,7 @@ export class WalnutRepository {
         nextCreditAmountMinor,
         nextDirection,
         nextNormalizedType,
+        nextCategoryId,
         nextCategory,
         nextReference,
         JSON.stringify(nextTags),
@@ -1309,7 +1546,23 @@ export class WalnutRepository {
             fromType: current.normalizedType,
             toType: input.normalizedType,
             title: 'Create a rule from this type change later',
-            description: 'Walnut can use this correction as a suggestion when reusable rules are introduced.'
+            description: 'Walnut can use this correction as a reusable rule suggestion.',
+            draft: {
+              name: `${detailDescriptionToRuleName(nextDescription)} rule`,
+              condition: {
+                descriptionContains: extractRuleKeywords(nextDescription),
+                amountMinMinor: undefined,
+                amountMaxMinor: undefined,
+                transactionTypes: [current.normalizedType],
+                tags: current.tags,
+                directions: [current.direction]
+              },
+              action: {
+                categoryId: nextCategoryId ?? undefined,
+                type: input.normalizedType,
+                appendTags: nextTags
+              }
+            }
           }
         : undefined
 
@@ -1371,6 +1624,235 @@ export class WalnutRepository {
       .all(input?.state ?? 'pending', input?.batchId ?? null, input?.batchId ?? null) as Record<string, unknown>[]
 
     return batchIds.map((row) => this.getImportBatchDetail({ batchId: String(row.batch_id) }))
+  }
+
+  listCategories(): CategoryTreeNode[] {
+    return this.buildCategoryTree()
+  }
+
+  createCategory(input: CreateCategoryInput): CategoryTreeNode[] {
+    const stamp = nowIso()
+    const parent = input.parentId ? this.getCategoryRow(input.parentId) : undefined
+    if (parent && !parent.is_active) {
+      throw new Error('Cannot create a category under an inactive parent.')
+    }
+
+    this.sqlite
+      .prepare(
+        `INSERT INTO categories
+         (id, name, parent_id, kind, is_system, is_income_category, is_active, sort_order, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        crypto.randomUUID(),
+        input.name.trim(),
+        input.parentId ?? null,
+        'user',
+        0,
+        input.isIncomeCategory ? 1 : 0,
+        1,
+        this.nextCategorySortOrder(input.parentId),
+        stamp,
+        stamp
+      )
+
+    return this.listCategories()
+  }
+
+  updateCategory(input: UpdateCategoryInput): CategoryTreeNode[] {
+    const current = this.getCategoryRow(input.categoryId)
+    const nextParentId = input.parentId === undefined ? current.parent_id ?? null : input.parentId
+    if (current.is_system && (input.parentId !== undefined || input.name !== undefined || input.isActive !== undefined)) {
+      throw new Error('System category properties are protected.')
+    }
+
+    if (nextParentId) {
+      this.assertValidCategoryParent(current.id, nextParentId)
+    }
+
+    this.sqlite
+      .prepare(
+        `UPDATE categories
+         SET name = ?, parent_id = ?, is_active = ?, updated_at = ?
+         WHERE id = ?`
+      )
+      .run(
+        input.name?.trim() ?? current.name,
+        nextParentId,
+        input.isActive === undefined ? current.is_active : input.isActive ? 1 : 0,
+        nowIso(),
+        input.categoryId
+      )
+
+    return this.listCategories()
+  }
+
+  mergeCategory(input: MergeCategoryInput): CategoryTreeNode[] {
+    const source = this.getCategoryRow(input.sourceCategoryId)
+    const target = this.getCategoryRow(input.targetCategoryId)
+    if (source.is_system) {
+      throw new Error('A system category cannot be used as the merge source.')
+    }
+
+    this.assertValidCategoryParent(target.id, source.id)
+
+    const transaction = this.sqlite.transaction(() => {
+      this.sqlite
+        .prepare('UPDATE imported_transactions SET category_id = ?, category_label = ? WHERE category_id = ?')
+        .run(
+          target.id,
+          this.getCategoryPathById(target.id).join(' > '),
+          source.id
+        )
+      this.sqlite.prepare('DELETE FROM categories WHERE id = ?').run(source.id)
+    })
+
+    transaction()
+    return this.listCategories()
+  }
+
+  deleteCategory(input: DeleteCategoryInput): CategoryTreeNode[] {
+    const category = this.getCategoryRow(input.categoryId)
+    if (category.is_system) {
+      throw new Error('Cannot delete a system category.')
+    }
+
+    const childCount = Number(
+      (
+        this.sqlite.prepare('SELECT COUNT(*) as count FROM categories WHERE parent_id = ?').get(input.categoryId) as {
+          count?: number
+        }
+      )?.count ?? 0
+    )
+
+    if (childCount > 0) {
+      throw new Error('Cannot delete a category that still has subcategories.')
+    }
+
+    const mappedCount = Number(
+      (
+        this.sqlite.prepare('SELECT COUNT(*) as count FROM imported_transactions WHERE category_id = ?').get(input.categoryId) as {
+          count?: number
+        }
+      )?.count ?? 0
+    )
+
+    if (mappedCount > 0) {
+      throw new Error('Cannot delete a category that is still assigned to transactions.')
+    }
+
+    this.sqlite.prepare('DELETE FROM categories WHERE id = ?').run(input.categoryId)
+    return this.listCategories()
+  }
+
+  listRules(): CategorizationRuleSummary[] {
+    const rows = this.sqlite
+      .prepare('SELECT * FROM categorization_rules ORDER BY is_system DESC, specificity_score DESC, sort_order ASC, name ASC')
+      .all() as Array<Record<string, unknown>>
+
+    return rows.map((row) => this.mapRuleSummary(row))
+  }
+
+  createRule(input: CreateCategorizationRuleInput): CategorizationRuleSummary[] {
+    const stamp = nowIso()
+    this.sqlite
+      .prepare(
+        `INSERT INTO categorization_rules
+         (id, name, kind, is_system, is_enabled, condition_json, action_json, specificity_score, sort_order, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        crypto.randomUUID(),
+        input.name.trim(),
+        'user',
+        0,
+        1,
+        JSON.stringify(this.normalizeRuleCondition(input.condition)),
+        JSON.stringify(this.normalizeRuleAction(input.action)),
+        this.computeRuleSpecificity(input.condition),
+        this.nextRuleSortOrder(),
+        stamp,
+        stamp
+      )
+
+    return this.listRules()
+  }
+
+  updateRule(input: UpdateCategorizationRuleInput): CategorizationRuleSummary[] {
+    const current = this.getRuleRow(input.ruleId)
+    const nextCondition = input.condition ? this.normalizeRuleCondition(input.condition) : this.parseRuleCondition(current.condition_json)
+    const nextAction = input.action ? this.normalizeRuleAction(input.action) : this.parseRuleAction(current.action_json)
+
+    this.sqlite
+      .prepare(
+        `UPDATE categorization_rules
+         SET name = ?, condition_json = ?, action_json = ?, is_enabled = ?, specificity_score = ?, updated_at = ?
+         WHERE id = ?`
+      )
+      .run(
+        input.name?.trim() ?? String(current.name),
+        JSON.stringify(nextCondition),
+        JSON.stringify(nextAction),
+        input.isEnabled === undefined ? current.is_enabled : input.isEnabled ? 1 : 0,
+        this.computeRuleSpecificity(nextCondition),
+        nowIso(),
+        input.ruleId
+      )
+
+    return this.listRules()
+  }
+
+  toggleRule(input: ToggleCategorizationRuleInput): CategorizationRuleSummary[] {
+    this.sqlite
+      .prepare('UPDATE categorization_rules SET is_enabled = ?, updated_at = ? WHERE id = ?')
+      .run(input.isEnabled ? 1 : 0, nowIso(), input.ruleId)
+
+    return this.listRules()
+  }
+
+  deleteRule(input: DeleteCategorizationRuleInput): CategorizationRuleSummary[] {
+    const row = this.getRuleRow(input.ruleId)
+    if (row.is_system) {
+      throw new Error('Cannot delete a system rule.')
+    }
+
+    this.sqlite.prepare('DELETE FROM categorization_rules WHERE id = ?').run(input.ruleId)
+    return this.listRules()
+  }
+
+  testRule(input: RulePreviewInput): RuleTestPreview {
+    return this.buildRulePreview(this.normalizeRuleCondition(input.condition), this.normalizeRuleAction(input.action), input.excludeRuleId)
+  }
+
+  previewRuleApplyToExisting(input: RulePreviewInput | ApplyRuleToExistingInput): RuleApplyPreview {
+    if ('ruleId' in input) {
+      const row = this.getRuleRow(input.ruleId)
+      return this.buildRulePreview(this.parseRuleCondition(row.condition_json), this.parseRuleAction(row.action_json), input.ruleId)
+    }
+
+    return this.buildRulePreview(this.normalizeRuleCondition(input.condition), this.normalizeRuleAction(input.action), input.excludeRuleId)
+  }
+
+  applyRuleToExisting(input: ApplyRuleToExistingInput): CategorizationRuleSummary[] {
+    const row = this.getRuleRow(input.ruleId)
+    const condition = this.parseRuleCondition(row.condition_json)
+    const action = this.parseRuleAction(row.action_json)
+    const preview = this.buildRulePreview(condition, action, input.ruleId)
+
+    const transaction = this.sqlite.transaction(() => {
+      for (const sample of preview.samples) {
+        this.applyRuleActionToTransaction(sample.transactionId, action)
+      }
+      if (preview.matchCount > preview.samples.length) {
+        const matches = this.findMatchingTransactions(condition, input.ruleId)
+        for (const match of matches) {
+          this.applyRuleActionToTransaction(String(match.id), action)
+        }
+      }
+    })
+
+    transaction()
+    return this.listRules()
   }
 
   resolveReviewItems(input: ReviewItemResolutionInput): ImportBatchDetail {
@@ -1470,8 +1952,8 @@ export class WalnutRepository {
     const insertTransaction = this.sqlite.prepare(
       `INSERT INTO imported_transactions
        (id, import_batch_id, source_file_id, transaction_date_raw, transaction_date_sortable, value_date_raw, raw_narration, cleaned_description,
-        debit_amount_minor, credit_amount_minor, running_balance_minor, direction, normalized_type, category_label, review_state_override, reference, transaction_signature, tags_json)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        debit_amount_minor, credit_amount_minor, running_balance_minor, direction, normalized_type, category_id, category_label, review_state_override, reference, transaction_signature, tags_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     const insertAttempt = this.sqlite.prepare(
       `INSERT INTO import_attempts
@@ -1524,6 +2006,24 @@ export class WalnutRepository {
         )
 
         for (const [index, row] of file.rows.entries()) {
+          const normalizedType = deriveNormalizedType({
+            cleanedDescription: row.cleanedDescription,
+            rawNarration: row.rawNarration,
+            reference: row.reference,
+            direction: row.direction
+          })
+          const starterCategorization = this.deriveStarterCategorization({
+            description: row.cleanedDescription,
+            rawNarration: row.rawNarration,
+            direction: row.direction,
+            normalizedType,
+            signedAmountMinor:
+              row.direction === 'credit'
+                ? Math.abs(row.creditAmountMinor ?? 0)
+                : -Math.abs(row.debitAmountMinor ?? 0),
+            tags: []
+          })
+
           insertTransaction.run(
             crypto.randomUUID(),
             input.batchId,
@@ -1537,17 +2037,13 @@ export class WalnutRepository {
             row.creditAmountMinor ?? null,
             row.runningBalanceMinor ?? null,
             row.direction,
-            deriveNormalizedType({
-              cleanedDescription: row.cleanedDescription,
-              rawNarration: row.rawNarration,
-              reference: row.reference,
-              direction: row.direction
-            }),
-            null,
+            normalizedType,
+            starterCategorization.categoryId ?? null,
+            starterCategorization.categoryPath?.join(' > ') ?? null,
             null,
             row.reference ?? null,
             file.transactionSignatures[index],
-            null
+            JSON.stringify(starterCategorization.tags)
           )
         }
       }
@@ -1849,6 +2345,337 @@ export class WalnutRepository {
     return JSON.parse(String(value)) as string[]
   }
 
+  private normalizeRuleCondition(condition: CategorizationRuleCondition): CategorizationRuleCondition {
+    return {
+      descriptionContains: (condition.descriptionContains ?? []).map((value) => value.trim()).filter(Boolean),
+      amountMinMinor: condition.amountMinMinor,
+      amountMaxMinor: condition.amountMaxMinor,
+      transactionTypes: condition.transactionTypes ?? [],
+      tags: (condition.tags ?? []).map((value) => value.trim()).filter(Boolean),
+      directions: condition.directions ?? []
+    }
+  }
+
+  private normalizeRuleAction(action: CategorizationRuleAction): CategorizationRuleAction {
+    return {
+      categoryId: action.categoryId,
+      type: action.type,
+      appendTags: (action.appendTags ?? []).map((value) => value.trim()).filter(Boolean)
+    }
+  }
+
+  private parseRuleCondition(value: unknown): CategorizationRuleCondition {
+    if (!value) {
+      return this.normalizeRuleCondition({
+        descriptionContains: [],
+        transactionTypes: [],
+        tags: [],
+        directions: []
+      })
+    }
+
+    return this.normalizeRuleCondition(JSON.parse(String(value)) as CategorizationRuleCondition)
+  }
+
+  private parseRuleAction(value: unknown): CategorizationRuleAction {
+    if (!value) {
+      return this.normalizeRuleAction({ appendTags: [] })
+    }
+
+    return this.normalizeRuleAction(JSON.parse(String(value)) as CategorizationRuleAction)
+  }
+
+  private computeRuleSpecificity(condition: CategorizationRuleCondition) {
+    const normalized = this.normalizeRuleCondition(condition)
+    return (
+      normalized.descriptionContains.length * 5 +
+      normalized.tags.length * 4 +
+      normalized.transactionTypes.length * 3 +
+      normalized.directions.length * 2 +
+      (normalized.amountMinMinor !== undefined ? 1 : 0) +
+      (normalized.amountMaxMinor !== undefined ? 1 : 0)
+    )
+  }
+
+  private getCategoryRow(categoryId: string) {
+    const row = this.sqlite.prepare('SELECT * FROM categories WHERE id = ?').get(categoryId) as Record<string, unknown> | undefined
+    if (!row) {
+      throw new Error(`Category ${categoryId} was not found.`)
+    }
+
+    return row
+  }
+
+  private getRuleRow(ruleId: string) {
+    const row = this.sqlite.prepare('SELECT * FROM categorization_rules WHERE id = ?').get(ruleId) as Record<string, unknown> | undefined
+    if (!row) {
+      throw new Error(`Rule ${ruleId} was not found.`)
+    }
+
+    return row
+  }
+
+  private assertValidCategoryParent(categoryId: string, nextParentId: string) {
+    if (categoryId === nextParentId) {
+      throw new Error('A category cannot be its own parent.')
+    }
+
+    let currentParentId: string | undefined = nextParentId
+    while (currentParentId) {
+      if (currentParentId === categoryId) {
+        throw new Error('A category cannot be moved under its own descendant.')
+      }
+
+      const row = this.sqlite.prepare('SELECT parent_id FROM categories WHERE id = ?').get(currentParentId) as { parent_id?: string | null } | undefined
+      currentParentId = row?.parent_id ?? undefined
+    }
+  }
+
+  private nextCategorySortOrder(parentId?: string | null) {
+    const row = this.sqlite
+      .prepare('SELECT COALESCE(MAX(sort_order), 0) as max_sort FROM categories WHERE (? IS NULL AND parent_id IS NULL) OR parent_id = ?')
+      .get(parentId ?? null, parentId ?? null) as { max_sort?: number } | undefined
+    return Number(row?.max_sort ?? 0) + 1
+  }
+
+  private nextRuleSortOrder() {
+    const row = this.sqlite.prepare('SELECT COALESCE(MAX(sort_order), 0) as max_sort FROM categorization_rules').get() as { max_sort?: number } | undefined
+    return Number(row?.max_sort ?? 0) + 1
+  }
+
+  private buildCategoryTree(): CategoryTreeNode[] {
+    const rows = this.sqlite.prepare('SELECT * FROM categories ORDER BY sort_order ASC, name ASC').all() as Array<Record<string, unknown>>
+    const directCounts = new Map<string, number>()
+    const transactionRows = this.sqlite
+      .prepare('SELECT category_id, COUNT(*) as count FROM imported_transactions WHERE category_id IS NOT NULL GROUP BY category_id')
+      .all() as Array<Record<string, unknown>>
+
+    for (const row of transactionRows) {
+      directCounts.set(String(row.category_id), Number(row.count ?? 0))
+    }
+
+    const nodes = new Map<string, CategoryTreeNode>()
+    for (const row of rows) {
+      nodes.set(String(row.id), {
+        id: String(row.id),
+        name: String(row.name),
+        kind: String(row.kind) === 'system' ? 'system' : 'user',
+        parentId: row.parent_id ? String(row.parent_id) : undefined,
+        path: [],
+        isActive: Boolean(row.is_active),
+        isIncomeCategory: Boolean(row.is_income_category),
+        sortOrder: Number(row.sort_order ?? 0),
+        counts: {
+          directTransactionCount: directCounts.get(String(row.id)) ?? 0,
+          totalTransactionCount: 0
+        },
+        children: []
+      })
+    }
+
+    const roots: CategoryTreeNode[] = []
+    for (const node of nodes.values()) {
+      node.path = this.getCategoryPathFromMap(node.id, nodes)
+      if (node.parentId && nodes.has(node.parentId)) {
+        nodes.get(node.parentId)!.children.push(node)
+      } else {
+        roots.push(node)
+      }
+    }
+
+    const computeTotals = (node: CategoryTreeNode): number => {
+      const childTotal = node.children.reduce((total, child) => total + computeTotals(child), 0)
+      node.counts.totalTransactionCount = node.counts.directTransactionCount + childTotal
+      return node.counts.totalTransactionCount
+    }
+
+    roots.forEach(computeTotals)
+    return roots.sort((left, right) => left.sortOrder - right.sortOrder)
+  }
+
+  private getCategoryPathFromMap(categoryId: string, nodes: Map<string, CategoryTreeNode>) {
+    const path: string[] = []
+    let current = nodes.get(categoryId)
+    while (current) {
+      path.unshift(current.name)
+      current = current.parentId ? nodes.get(current.parentId) : undefined
+    }
+    return path
+  }
+
+  private getCategoryPathById(categoryId?: string | null) {
+    if (!categoryId) {
+      return [] as string[]
+    }
+
+    const rows = this.sqlite.prepare('SELECT id, name, parent_id, kind, is_active, is_income_category, sort_order FROM categories ORDER BY sort_order ASC, name ASC').all() as Array<Record<string, unknown>>
+    const nodes = new Map<string, CategoryTreeNode>()
+    for (const row of rows) {
+      nodes.set(String(row.id), {
+        id: String(row.id),
+        name: String(row.name),
+        kind: String(row.kind) === 'system' ? 'system' : 'user',
+        parentId: row.parent_id ? String(row.parent_id) : undefined,
+        path: [],
+        isActive: Boolean(row.is_active),
+        isIncomeCategory: Boolean(row.is_income_category),
+        sortOrder: Number(row.sort_order ?? 0),
+        counts: { directTransactionCount: 0, totalTransactionCount: 0 },
+        children: []
+      })
+    }
+
+    return this.getCategoryPathFromMap(categoryId, nodes)
+  }
+
+  private findMatchingTransactions(condition: CategorizationRuleCondition, excludeRuleId?: string) {
+    const rows = this.sqlite
+      .prepare(
+        `SELECT t.*, s.file_name, a.batch_label, a.imported_at,
+            CASE
+              WHEN EXISTS (
+                SELECT 1
+                FROM review_items r
+                WHERE r.batch_id = t.import_batch_id
+                  AND r.state = 'pending'
+              ) THEN 1
+              ELSE 0
+            END AS has_pending_review
+         FROM imported_transactions t
+         INNER JOIN import_source_files s ON s.id = t.source_file_id
+         INNER JOIN import_attempts a ON a.batch_id = t.import_batch_id`
+      )
+      .all() as Array<Record<string, unknown>>
+
+    const normalized = this.normalizeRuleCondition(condition)
+    return rows.filter((row) => this.matchesRuleCondition(this.mapTransactionLedgerRow(row), normalized, excludeRuleId))
+  }
+
+  private matchesRuleCondition(row: TransactionLedgerRow, condition: CategorizationRuleCondition, excludeRuleId?: string) {
+    void excludeRuleId
+    const text = row.description.toLowerCase()
+    if (condition.descriptionContains.length && !condition.descriptionContains.every((keyword) => text.includes(keyword.toLowerCase()))) {
+      return false
+    }
+    if (condition.amountMinMinor !== undefined && Math.abs(row.signedAmountMinor) < condition.amountMinMinor) {
+      return false
+    }
+    if (condition.amountMaxMinor !== undefined && Math.abs(row.signedAmountMinor) > condition.amountMaxMinor) {
+      return false
+    }
+    if (condition.transactionTypes.length && !condition.transactionTypes.includes(row.normalizedType)) {
+      return false
+    }
+    if (condition.tags.length && !condition.tags.every((tag) => row.tags.includes(tag))) {
+      return false
+    }
+    const direction: CategoryDirection = row.signedAmountMinor >= 0 ? 'credit' : 'debit'
+    if (condition.directions.length && !condition.directions.includes(direction)) {
+      return false
+    }
+    return true
+  }
+
+  private buildRulePreview(condition: CategorizationRuleCondition, action: CategorizationRuleAction, excludeRuleId?: string): RuleApplyPreview {
+    const matches = this.findMatchingTransactions(condition, excludeRuleId)
+    const samples = matches.slice(0, 10).map((row) => this.mapRulePreviewSample(row, action))
+    return {
+      matchCount: matches.length,
+      samples
+    }
+  }
+
+  private mapRulePreviewSample(row: Record<string, unknown> | TransactionLedgerRow, action: CategorizationRuleAction): RulePreviewSample {
+    const ledgerRow = 'description' in row && 'normalizedType' in row ? (row as TransactionLedgerRow) : this.mapTransactionLedgerRow(row as Record<string, unknown>)
+    const nextCategoryPath = action.categoryId ? this.getCategoryPathById(action.categoryId) : ledgerRow.categoryPath
+    return {
+      transactionId: ledgerRow.id,
+      transactionDateRaw: ledgerRow.transactionDateRaw,
+      description: ledgerRow.description,
+      signedAmountMinor: ledgerRow.signedAmountMinor,
+      currentCategoryPath: ledgerRow.categoryPath,
+      nextCategoryPath,
+      currentType: ledgerRow.normalizedType,
+      nextType: action.type ?? ledgerRow.normalizedType,
+      tags: Array.from(new Set([...ledgerRow.tags, ...(action.appendTags ?? [])]))
+    }
+  }
+
+  private applyRuleActionToTransaction(transactionId: string, action: CategorizationRuleAction) {
+    const row = this.getTransactionDetail({ transactionId })
+    const nextTags = Array.from(new Set([...row.tags, ...(action.appendTags ?? [])]))
+    const nextCategoryPath = action.categoryId ? this.getCategoryPathById(action.categoryId) : row.categoryPath ?? []
+    this.sqlite
+      .prepare(
+        `UPDATE imported_transactions
+         SET normalized_type = ?, category_id = ?, category_label = ?, tags_json = ?
+         WHERE id = ?`
+      )
+      .run(
+        action.type ?? row.normalizedType,
+        action.categoryId ?? row.categoryId ?? null,
+        nextCategoryPath.length ? nextCategoryPath.join(' > ') : null,
+        JSON.stringify(nextTags),
+        transactionId
+      )
+  }
+
+  private mapRuleSummary(row: Record<string, unknown>): CategorizationRuleSummary {
+    const condition = this.parseRuleCondition(row.condition_json)
+    const action = this.parseRuleAction(row.action_json)
+    return {
+      id: String(row.id),
+      name: String(row.name),
+      kind: String(row.kind) === 'system' ? 'system' : 'user',
+      isEnabled: Boolean(row.is_enabled),
+      condition,
+      action,
+      specificityScore: Number(row.specificity_score ?? this.computeRuleSpecificity(condition)),
+      affectedTransactionCount: this.buildRulePreview(condition, action, String(row.id)).matchCount,
+      updatedAt: String(row.updated_at)
+    }
+  }
+
+  private deriveStarterCategorization(input: {
+    description: string
+    rawNarration: string
+    direction: 'debit' | 'credit'
+    normalizedType: TransactionNormalizedType
+    signedAmountMinor: number
+    tags: string[]
+  }) {
+    const text = `${input.description} ${input.rawNarration}`.toLowerCase()
+    if (input.normalizedType === 'income' && text.includes('salary')) {
+      return {
+        categoryId: categoryId('income-salary'),
+        categoryPath: this.getCategoryPathById(categoryId('income-salary')),
+        tags: ['salary']
+      }
+    }
+
+    if (input.normalizedType === 'atm-withdrawal') {
+      return {
+        categoryId: categoryId('cash-atm'),
+        categoryPath: this.getCategoryPathById(categoryId('cash-atm')),
+        tags: ['cash']
+      }
+    }
+
+    if (input.normalizedType === 'credit-card-payment') {
+      return {
+        categoryId: categoryId('credit-card-payment'),
+        categoryPath: this.getCategoryPathById(categoryId('credit-card-payment')),
+        tags: []
+      }
+    }
+
+    return {
+      categoryId: undefined,
+      categoryPath: undefined,
+      tags: input.tags
+    }
+  }
+
   private mapImportAttemptSummary(row: Record<string, unknown>): ImportAttemptSummary {
     const batchId = String(row.batch_id)
     const acceptedTransactionCount = this.sqlite
@@ -1941,6 +2768,8 @@ export class WalnutRepository {
   }
 
   private mapImportedTransaction(row: Record<string, unknown>) {
+    const categoryIdValue = row.category_id ? String(row.category_id) : undefined
+    const categoryPath = categoryIdValue ? this.getCategoryPathById(categoryIdValue) : undefined
     return {
       id: String(row.id),
       transactionDateRaw: String(row.transaction_date_raw),
@@ -1960,7 +2789,13 @@ export class WalnutRepository {
             reference: row.reference ? String(row.reference) : undefined,
             direction: String(row.direction) as 'debit' | 'credit'
           })) as TransactionNormalizedType,
-      category: row.category_label ? String(row.category_label) : undefined,
+      categoryId: categoryIdValue,
+      categoryPath,
+      category: row.category_label
+        ? String(row.category_label)
+        : categoryPath?.length
+          ? categoryPath.join(' > ')
+          : undefined,
       reviewStateOverride: row.review_state_override ? (String(row.review_state_override) as TransactionReviewState) : undefined,
       reference: row.reference ? String(row.reference) : undefined,
       tags: this.parseTagsJson(row.tags_json),
@@ -1988,6 +2823,8 @@ export class WalnutRepository {
       runningBalanceMinor: importedTransaction.runningBalanceMinor,
       normalizedType: importedTransaction.normalizedType,
       tags: importedTransaction.tags ?? [],
+      categoryId: importedTransaction.categoryId,
+      categoryPath: importedTransaction.categoryPath,
       category: importedTransaction.category,
       reference: importedTransaction.reference,
       reviewState

--- a/src/main/persistence/schema.ts
+++ b/src/main/persistence/schema.ts
@@ -115,11 +115,38 @@ export const importedTransactions = sqliteTable('imported_transactions', {
   runningBalanceMinor: integer('running_balance_minor'),
   direction: text('direction').notNull(),
   normalizedType: text('normalized_type'),
+  categoryId: text('category_id'),
   categoryLabel: text('category_label'),
   reviewStateOverride: text('review_state_override'),
   reference: text('reference'),
   transactionSignature: text('transaction_signature').notNull(),
   tagsJson: text('tags_json')
+})
+
+export const categories = sqliteTable('categories', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  parentId: text('parent_id'),
+  kind: text('kind').notNull(),
+  isSystem: integer('is_system', { mode: 'boolean' }).notNull().default(false),
+  isIncomeCategory: integer('is_income_category', { mode: 'boolean' }).notNull().default(false),
+  isActive: integer('is_active', { mode: 'boolean' }).notNull().default(true),
+  sortOrder: integer('sort_order').notNull().default(0),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull()
+})
+
+export const categorizationRules = sqliteTable('categorization_rules', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  kind: text('kind').notNull(),
+  isSystem: integer('is_system', { mode: 'boolean' }).notNull().default(false),
+  isEnabled: integer('is_enabled', { mode: 'boolean' }).notNull().default(true),
+  conditionJson: text('condition_json').notNull(),
+  actionJson: text('action_json').notNull(),
+  specificityScore: integer('specificity_score').notNull().default(0),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull()
 })
 
 export const reviewItems = sqliteTable('review_items', {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -27,6 +27,19 @@ const walnutApi: WalnutApi = {
   listTransactions: (input) => ipcRenderer.invoke('transactions:list', input),
   getTransactionDetail: (input) => ipcRenderer.invoke('transactions:get-detail', input),
   updateTransaction: (input) => ipcRenderer.invoke('transactions:update', input),
+  listCategories: () => ipcRenderer.invoke('categories:list'),
+  createCategory: (input) => ipcRenderer.invoke('categories:create', input),
+  updateCategory: (input) => ipcRenderer.invoke('categories:update', input),
+  mergeCategory: (input) => ipcRenderer.invoke('categories:merge', input),
+  deleteCategory: (input) => ipcRenderer.invoke('categories:delete', input),
+  listRules: () => ipcRenderer.invoke('rules:list'),
+  createRule: (input) => ipcRenderer.invoke('rules:create', input),
+  updateRule: (input) => ipcRenderer.invoke('rules:update', input),
+  toggleRule: (input) => ipcRenderer.invoke('rules:toggle', input),
+  deleteRule: (input) => ipcRenderer.invoke('rules:delete', input),
+  testRule: (input) => ipcRenderer.invoke('rules:test', input),
+  previewRuleApplyToExisting: (input) => ipcRenderer.invoke('rules:preview-apply', input),
+  applyRuleToExisting: (input) => ipcRenderer.invoke('rules:apply', input),
   ping: () => ipcRenderer.invoke('app-state:ping')
 }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,7 +1,9 @@
-import { FileSpreadsheet, History, LayoutDashboard, LockKeyhole, Rows3, ShieldCheck } from 'lucide-react'
+import { FileSpreadsheet, History, LayoutDashboard, LockKeyhole, Rows3, ShieldCheck, Tags } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import type { AppShellState } from '../shared/contracts/app-state'
+import type { TransactionRuleSuggestion } from '../shared/contracts/transactions'
 import { EmptyDashboard } from './features/dashboard/EmptyDashboard'
+import { CategoriesRulesScreen } from './features/categories-rules/CategoriesRulesScreen'
 import { ImportBatchDetailScreen } from './features/import/ImportBatchDetailScreen'
 import { ImportHistoryScreen } from './features/import/ImportHistoryScreen'
 import { ImportWorkspace } from './features/import/ImportWorkspace'
@@ -40,8 +42,9 @@ type ImportAreaScreen =
 
 export const App = () => {
   const [state, setState] = useState<AppShellState>(fallbackState)
-  const [workspaceScreen, setWorkspaceScreen] = useState<'home' | 'imports' | 'transactions'>('home')
+  const [workspaceScreen, setWorkspaceScreen] = useState<'home' | 'imports' | 'transactions' | 'categories-rules'>('home')
   const [importAreaScreen, setImportAreaScreen] = useState<ImportAreaScreen>({ type: 'workspace' })
+  const [ruleSuggestionDraft, setRuleSuggestionDraft] = useState<TransactionRuleSuggestion['draft']>()
   const [loading, setLoading] = useState(true)
 
   const workspaceSidebar = (
@@ -96,6 +99,17 @@ export const App = () => {
           }}
         >
           <History size={18} />
+        </button>
+        <button
+          type="button"
+          aria-label="Open categories and rules workspace"
+          style={{
+            ...sidebarStyles.navButton,
+            ...(workspaceScreen === 'categories-rules' ? sidebarStyles.navButtonActive : undefined)
+          }}
+          onClick={() => setWorkspaceScreen('categories-rules')}
+        >
+          <Tags size={18} />
         </button>
       </div>
 
@@ -163,6 +177,8 @@ export const App = () => {
           ? 'Stage, review, and import without storing source files'
           : workspaceScreen === 'transactions'
             ? 'Search, filter, and correct imported records from one local ledger'
+            : workspaceScreen === 'categories-rules'
+              ? 'Manage protected categories, user taxonomy, and reusable rule automation'
             : 'Your local finance workspace is ready'
       }
       sidebar={workspaceSidebar}
@@ -200,7 +216,17 @@ export const App = () => {
           />
         )
       ) : workspaceScreen === 'transactions' ? (
-        <TransactionsScreen />
+        <TransactionsScreen
+          onUseRuleSuggestion={(suggestion) => {
+            setRuleSuggestionDraft(suggestion.draft)
+            setWorkspaceScreen('categories-rules')
+          }}
+        />
+      ) : workspaceScreen === 'categories-rules' ? (
+        <CategoriesRulesScreen
+          initialRuleDraft={ruleSuggestionDraft}
+          onRuleDraftHandled={() => setRuleSuggestionDraft(undefined)}
+        />
       ) : (
         <EmptyDashboard onImport={() => setWorkspaceScreen('imports')} />
       )}

--- a/src/renderer/features/categories-rules/CategoriesRulesScreen.tsx
+++ b/src/renderer/features/categories-rules/CategoriesRulesScreen.tsx
@@ -1,0 +1,262 @@
+import { useEffect, useMemo, useState } from 'react'
+import type {
+  CategoryTreeNode,
+  CategorizationRuleSummary,
+  CreateCategoryInput,
+  CreateCategorizationRuleInput,
+  RuleApplyPreview,
+  UpdateCategoryInput,
+  UpdateCategorizationRuleInput
+} from '../../../shared/contracts/categories'
+import type { TransactionRuleSuggestion } from '../../../shared/contracts/transactions'
+import { CategoryEditorPanel } from './CategoryEditorPanel'
+import { CategoryPane } from './CategoryPane'
+import { RuleEditorPanel } from './RuleEditorPanel'
+import { RulePane } from './RulePane'
+import { RulePreviewPanel } from './RulePreviewPanel'
+
+type CategoryEditorState =
+  | { mode: 'create' }
+  | { mode: 'edit'; category: CategoryTreeNode }
+  | null
+
+type RuleEditorState =
+  | { mode: 'create'; draft?: TransactionRuleSuggestion['draft'] }
+  | { mode: 'edit'; rule: CategorizationRuleSummary }
+  | null
+
+interface CategoriesRulesScreenProps {
+  initialRuleDraft?: TransactionRuleSuggestion['draft']
+  onRuleDraftHandled?: () => void
+}
+
+const flattenCategories = (nodes: CategoryTreeNode[]): CategoryTreeNode[] =>
+  nodes.flatMap((node) => [node, ...flattenCategories(node.children)])
+
+export const CategoriesRulesScreen = ({ initialRuleDraft, onRuleDraftHandled }: CategoriesRulesScreenProps) => {
+  const [categories, setCategories] = useState<CategoryTreeNode[]>([])
+  const [rules, setRules] = useState<CategorizationRuleSummary[]>([])
+  const [categoryEditor, setCategoryEditor] = useState<CategoryEditorState>(null)
+  const [ruleEditor, setRuleEditor] = useState<RuleEditorState>(null)
+  const [rulePreview, setRulePreview] = useState<RuleApplyPreview>()
+  const [previewRuleId, setPreviewRuleId] = useState<string>()
+
+  const reload = async () => {
+    const [nextCategories, nextRules] = await Promise.all([window.walnut.listCategories(), window.walnut.listRules()])
+    setCategories(nextCategories)
+    setRules(nextRules)
+  }
+
+  useEffect(() => {
+    void reload()
+  }, [])
+
+  useEffect(() => {
+    if (initialRuleDraft) {
+      setRuleEditor({ mode: 'create', draft: initialRuleDraft })
+      onRuleDraftHandled?.()
+    }
+  }, [initialRuleDraft, onRuleDraftHandled])
+
+  const categoryOptions = useMemo(
+    () =>
+      flattenCategories(categories).map((category) => ({
+        id: category.id,
+        label: category.path.join(' > '),
+        kind: category.kind,
+        isActive: category.isActive
+      })),
+    [categories]
+  )
+
+  const handleSaveCategory = async (input: CreateCategoryInput | UpdateCategoryInput) => {
+    if ('categoryId' in input) {
+      setCategories(await window.walnut.updateCategory(input))
+    } else {
+      setCategories(await window.walnut.createCategory(input))
+    }
+    setCategoryEditor(null)
+  }
+
+  const handleMergeCategory = async (sourceCategoryId: string, targetCategoryId: string) => {
+    setCategories(await window.walnut.mergeCategory({ sourceCategoryId, targetCategoryId }))
+    setCategoryEditor(null)
+  }
+
+  const handleDeleteCategory = async (categoryId: string) => {
+    setCategories(await window.walnut.deleteCategory({ categoryId }))
+    setCategoryEditor(null)
+  }
+
+  const handleSaveRule = async (input: CreateCategorizationRuleInput | UpdateCategorizationRuleInput, previewAfterSave?: boolean) => {
+    const nextRules =
+      'ruleId' in input ? await window.walnut.updateRule(input) : await window.walnut.createRule(input)
+    setRules(nextRules)
+
+    if (previewAfterSave) {
+      const matchedRule =
+        [...nextRules]
+          .reverse()
+          .find((rule) => rule.name === input.name && rule.kind === 'user') ??
+        ('ruleId' in input ? nextRules.find((rule) => rule.id === input.ruleId) : undefined)
+
+      if (matchedRule) {
+        setPreviewRuleId(matchedRule.id)
+        setRulePreview(await window.walnut.previewRuleApplyToExisting({ ruleId: matchedRule.id }))
+      }
+    } else {
+      setRuleEditor(null)
+    }
+  }
+
+  return (
+    <section style={styles.root}>
+      <section style={styles.headerCard}>
+        <div>
+          <div style={styles.kicker}>Category automation workspace</div>
+          <h2 style={styles.heading}>Categories &amp; Rules</h2>
+          <p style={styles.helper}>Keep the built-in taxonomy protected, manage your own categories, and preview reusable automation before it touches existing transactions.</p>
+        </div>
+        <div style={styles.headerActions}>
+          <button type="button" style={styles.secondaryButton} onClick={() => setCategoryEditor({ mode: 'create' })}>
+            New category
+          </button>
+          <button type="button" style={styles.primaryButton} onClick={() => setRuleEditor({ mode: 'create' })}>
+            New rule
+          </button>
+        </div>
+      </section>
+
+      <div style={styles.workspace}>
+        <CategoryPane categories={categories} onCreate={() => setCategoryEditor({ mode: 'create' })} onEdit={(category) => setCategoryEditor({ mode: 'edit', category })} />
+        <RulePane
+          rules={rules}
+          onCreate={() => setRuleEditor({ mode: 'create' })}
+          onEdit={(rule) => setRuleEditor({ mode: 'edit', rule })}
+          onToggle={async (rule) => setRules(await window.walnut.toggleRule({ ruleId: rule.id, isEnabled: !rule.isEnabled }))}
+        />
+      </div>
+
+      {categoryEditor ? (
+        <CategoryEditorPanel
+          mode={categoryEditor.mode}
+          category={categoryEditor.mode === 'edit' ? categoryEditor.category : undefined}
+          categoryOptions={categoryOptions}
+          onClose={() => setCategoryEditor(null)}
+          onSave={handleSaveCategory}
+          onMerge={handleMergeCategory}
+          onDelete={handleDeleteCategory}
+        />
+      ) : null}
+
+      {ruleEditor ? (
+        <RuleEditorPanel
+          mode={ruleEditor.mode}
+          rule={ruleEditor.mode === 'edit' ? ruleEditor.rule : undefined}
+          draft={ruleEditor.mode === 'create' ? ruleEditor.draft : undefined}
+          categoryOptions={categoryOptions}
+          onClose={() => {
+            setRuleEditor(null)
+            setRulePreview(undefined)
+            setPreviewRuleId(undefined)
+          }}
+          onSave={handleSaveRule}
+          onDelete={async (ruleId) => {
+            setRules(await window.walnut.deleteRule({ ruleId }))
+            setRuleEditor(null)
+          }}
+          onTest={async (previewInput) => {
+            setRulePreview(await window.walnut.testRule(previewInput))
+            setPreviewRuleId(undefined)
+          }}
+          onPreviewApply={async (input) => {
+            await handleSaveRule(input, true)
+          }}
+        />
+      ) : null}
+
+      {rulePreview ? (
+        <RulePreviewPanel
+          preview={rulePreview}
+          onClose={() => {
+            setRulePreview(undefined)
+            setPreviewRuleId(undefined)
+            setRuleEditor(null)
+          }}
+          onApply={
+            previewRuleId
+              ? async () => {
+                  setRules(await window.walnut.applyRuleToExisting({ ruleId: previewRuleId }))
+                  setRulePreview(undefined)
+                  setPreviewRuleId(undefined)
+                  setRuleEditor(null)
+                }
+              : undefined
+          }
+        />
+      ) : null}
+    </section>
+  )
+}
+
+const styles = {
+  root: {
+    display: 'grid',
+    gap: 'var(--space-lg)'
+  },
+  headerCard: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'end',
+    gap: 'var(--space-lg)',
+    padding: 'var(--space-lg)',
+    borderRadius: 'var(--radius-lg)',
+    border: '1px solid var(--color-border)',
+    background: 'rgba(245, 241, 232, 0.72)',
+    boxShadow: 'var(--shadow-panel)'
+  },
+  kicker: {
+    fontSize: 14,
+    fontWeight: 600,
+    color: 'var(--color-accent)'
+  },
+  heading: {
+    margin: 'var(--space-sm) 0 0 0',
+    fontSize: 'var(--font-display-size)',
+    lineHeight: 1.1
+  },
+  helper: {
+    margin: 'var(--space-sm) 0 0 0',
+    color: 'var(--color-muted)',
+    maxWidth: 760
+  },
+  headerActions: {
+    display: 'flex',
+    gap: 'var(--space-sm)',
+    flexWrap: 'wrap' as const
+  },
+  workspace: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0, 1.02fr) minmax(0, 0.98fr)',
+    gap: 'var(--space-lg)',
+    alignItems: 'start'
+  },
+  secondaryButton: {
+    minHeight: 44,
+    borderRadius: 999,
+    border: '1px solid rgba(30, 27, 22, 0.18)',
+    background: 'rgba(30, 27, 22, 0.04)',
+    color: 'var(--color-ink)',
+    padding: '0 18px',
+    fontWeight: 600
+  },
+  primaryButton: {
+    minHeight: 44,
+    border: 0,
+    borderRadius: 999,
+    background: 'var(--color-accent)',
+    color: '#fff',
+    padding: '0 18px',
+    fontWeight: 700
+  }
+} as const

--- a/src/renderer/features/categories-rules/CategoryEditorPanel.tsx
+++ b/src/renderer/features/categories-rules/CategoryEditorPanel.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useState } from 'react'
+import type { CategoryOption, CategoryTreeNode, CreateCategoryInput, UpdateCategoryInput } from '../../../shared/contracts/categories'
+
+interface CategoryEditorPanelProps {
+  mode: 'create' | 'edit'
+  category?: CategoryTreeNode
+  categoryOptions: CategoryOption[]
+  onClose: () => void
+  onSave: (input: CreateCategoryInput | UpdateCategoryInput) => void
+  onMerge: (sourceCategoryId: string, targetCategoryId: string) => void
+  onDelete: (categoryId: string) => void
+}
+
+export const CategoryEditorPanel = ({ mode, category, categoryOptions, onClose, onSave, onMerge, onDelete }: CategoryEditorPanelProps) => {
+  const [name, setName] = useState('')
+  const [parentId, setParentId] = useState('')
+  const [isActive, setIsActive] = useState(true)
+  const [mergeTargetId, setMergeTargetId] = useState('')
+
+  useEffect(() => {
+    setName(category?.name ?? '')
+    setParentId(category?.parentId ?? '')
+    setIsActive(category?.isActive ?? true)
+    setMergeTargetId('')
+  }, [category])
+
+  return (
+    <aside style={styles.panel}>
+      <div style={styles.header}>
+        <div>
+          <div style={styles.kicker}>{mode === 'create' ? 'New category' : 'Manage category'}</div>
+          <h3 style={styles.heading}>{mode === 'create' ? 'Create a user category' : category?.name}</h3>
+        </div>
+        <button type="button" style={styles.secondaryButton} onClick={onClose}>
+          Close
+        </button>
+      </div>
+
+      <label style={styles.field}>
+        <span style={styles.label}>Name</span>
+        <input value={name} onChange={(event) => setName(event.target.value)} style={styles.input} />
+      </label>
+
+      <label style={styles.field}>
+        <span style={styles.label}>Parent category</span>
+        <select value={parentId} onChange={(event) => setParentId(event.target.value)} style={styles.input}>
+          <option value="">Top level</option>
+          {categoryOptions
+            .filter((option) => option.id !== category?.id)
+            .map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+        </select>
+      </label>
+
+      {mode === 'edit' ? (
+        <label style={styles.toggleRow}>
+          <input type="checkbox" checked={isActive} onChange={(event) => setIsActive(event.target.checked)} />
+          <span>Category is active</span>
+        </label>
+      ) : null}
+
+      <div style={styles.actions}>
+        <button
+          type="button"
+          style={styles.primaryButton}
+          onClick={() =>
+            onSave(
+              mode === 'create'
+                ? {
+                    name,
+                    parentId: parentId || undefined
+                  }
+                : {
+                    categoryId: category!.id,
+                    name,
+                    parentId: parentId || null,
+                    isActive
+                  }
+            )
+          }
+        >
+          {mode === 'create' ? 'Create category' : 'Save category'}
+        </button>
+      </div>
+
+      {mode === 'edit' && category ? (
+        <div style={styles.destructiveBlock}>
+          <div style={styles.label}>Merge into another category</div>
+          <select value={mergeTargetId} onChange={(event) => setMergeTargetId(event.target.value)} style={styles.input}>
+            <option value="">Select target</option>
+            {categoryOptions
+              .filter((option) => option.id !== category.id)
+              .map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+          </select>
+          <div style={styles.actions}>
+            <button type="button" style={styles.secondaryButton} disabled={!mergeTargetId} onClick={() => onMerge(category.id, mergeTargetId)}>
+              Merge category
+            </button>
+            <button type="button" style={styles.destructiveButton} onClick={() => onDelete(category.id)}>
+              Delete category
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </aside>
+  )
+}
+
+const styles = {
+  panel: {
+    position: 'fixed' as const,
+    top: 110,
+    right: 24,
+    bottom: 24,
+    width: 420,
+    display: 'grid',
+    gap: 'var(--space-md)',
+    padding: 'var(--space-lg)',
+    borderRadius: 'var(--radius-lg)',
+    border: '1px solid var(--color-border)',
+    background: 'rgba(245, 241, 232, 0.96)',
+    boxShadow: 'var(--shadow-panel)',
+    zIndex: 30,
+    overflowY: 'auto' as const
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: 'var(--space-md)'
+  },
+  kicker: {
+    fontSize: 14,
+    fontWeight: 600,
+    color: 'var(--color-accent)'
+  },
+  heading: {
+    margin: 'var(--space-xs) 0 0 0',
+    fontSize: 24
+  },
+  field: {
+    display: 'grid',
+    gap: 'var(--space-xs)'
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: 600
+  },
+  input: {
+    minHeight: 44,
+    borderRadius: 16,
+    border: '1px solid rgba(15, 118, 110, 0.18)',
+    background: 'rgba(255, 255, 255, 0.9)',
+    padding: '0 14px'
+  },
+  toggleRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 'var(--space-sm)'
+  },
+  actions: {
+    display: 'flex',
+    gap: 'var(--space-sm)',
+    flexWrap: 'wrap' as const
+  },
+  primaryButton: {
+    minHeight: 42,
+    border: 0,
+    borderRadius: 999,
+    background: 'var(--color-accent)',
+    color: '#fff',
+    padding: '0 16px',
+    fontWeight: 700
+  },
+  secondaryButton: {
+    minHeight: 42,
+    borderRadius: 999,
+    border: '1px solid rgba(30, 27, 22, 0.18)',
+    background: 'rgba(30, 27, 22, 0.04)',
+    color: 'var(--color-ink)',
+    padding: '0 16px',
+    fontWeight: 600
+  },
+  destructiveBlock: {
+    display: 'grid',
+    gap: 'var(--space-sm)',
+    paddingTop: 'var(--space-sm)',
+    borderTop: '1px solid rgba(30, 27, 22, 0.08)'
+  },
+  destructiveButton: {
+    minHeight: 42,
+    borderRadius: 999,
+    border: '1px solid rgba(180, 35, 24, 0.24)',
+    background: 'rgba(180, 35, 24, 0.08)',
+    color: 'var(--color-destructive)',
+    padding: '0 16px',
+    fontWeight: 700
+  }
+} as const

--- a/src/renderer/features/categories-rules/CategoryPane.tsx
+++ b/src/renderer/features/categories-rules/CategoryPane.tsx
@@ -1,0 +1,161 @@
+import type { CategoryTreeNode } from '../../../shared/contracts/categories'
+
+interface CategoryPaneProps {
+  categories: CategoryTreeNode[]
+  onCreate: () => void
+  onEdit: (category: CategoryTreeNode) => void
+}
+
+const renderRows = (categories: CategoryTreeNode[], onEdit: (category: CategoryTreeNode) => void, depth = 0): JSX.Element[] =>
+  categories.flatMap((category) => [
+    <div key={category.id} style={{ ...styles.row, paddingLeft: 20 + depth * 20 }}>
+      <div style={styles.rowContent}>
+        <div style={styles.rowTop}>
+          <strong>{category.name}</strong>
+          <div style={styles.badges}>
+            {category.kind === 'system' ? <span style={styles.systemBadge}>Protected</span> : null}
+            {!category.isActive ? <span style={styles.inactiveBadge}>Inactive</span> : null}
+          </div>
+        </div>
+        <div style={styles.rowMeta}>
+          <span>{category.path.join(' > ')}</span>
+          <span>{category.counts.totalTransactionCount} mapped</span>
+        </div>
+      </div>
+      <button
+        type="button"
+        style={category.kind === 'system' ? styles.ghostButtonDisabled : styles.ghostButton}
+        onClick={() => onEdit(category)}
+        disabled={category.kind === 'system'}
+      >
+        {category.kind === 'system' ? 'Fixed' : 'Manage'}
+      </button>
+    </div>,
+    ...renderRows(category.children, onEdit, depth + 1)
+  ])
+
+export const CategoryPane = ({ categories, onCreate, onEdit }: CategoryPaneProps) => (
+  <section style={styles.card}>
+    <div style={styles.header}>
+      <div>
+        <div style={styles.kicker}>Category hierarchy</div>
+        <h3 style={styles.heading}>Protected defaults and local custom categories</h3>
+      </div>
+      <button type="button" style={styles.primaryButton} onClick={onCreate}>
+        Add category
+      </button>
+    </div>
+
+    {categories.length === 0 ? <p style={styles.empty}>No custom categories yet</p> : <div style={styles.list}>{renderRows(categories, onEdit)}</div>}
+  </section>
+)
+
+const styles = {
+  card: {
+    display: 'grid',
+    gap: 'var(--space-md)',
+    padding: 'var(--space-lg)',
+    borderRadius: 'var(--radius-lg)',
+    border: '1px solid var(--color-border)',
+    background: 'rgba(245, 241, 232, 0.72)',
+    boxShadow: 'var(--shadow-panel)'
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'start',
+    gap: 'var(--space-md)'
+  },
+  kicker: {
+    fontSize: 14,
+    fontWeight: 600,
+    color: 'var(--color-accent)'
+  },
+  heading: {
+    margin: 'var(--space-xs) 0 0 0',
+    fontSize: 22
+  },
+  list: {
+    display: 'grid',
+    gap: 'var(--space-sm)'
+  },
+  row: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0, 1fr) auto',
+    gap: 'var(--space-md)',
+    alignItems: 'center',
+    padding: 'var(--space-md)',
+    borderRadius: 18,
+    background: 'rgba(255, 255, 255, 0.56)',
+    border: '1px solid rgba(30, 27, 22, 0.08)'
+  },
+  rowContent: {
+    display: 'grid',
+    gap: 'var(--space-xs)'
+  },
+  rowTop: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 'var(--space-sm)',
+    flexWrap: 'wrap' as const
+  },
+  rowMeta: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: 'var(--space-sm)',
+    flexWrap: 'wrap' as const,
+    color: 'var(--color-muted)',
+    fontSize: 14
+  },
+  badges: {
+    display: 'flex',
+    gap: 'var(--space-xs)'
+  },
+  systemBadge: {
+    padding: '4px 10px',
+    borderRadius: 999,
+    background: 'rgba(15, 118, 110, 0.1)',
+    color: 'var(--color-accent)',
+    fontSize: 12,
+    fontWeight: 700
+  },
+  inactiveBadge: {
+    padding: '4px 10px',
+    borderRadius: 999,
+    background: 'rgba(30, 27, 22, 0.06)',
+    color: 'var(--color-muted)',
+    fontSize: 12,
+    fontWeight: 700
+  },
+  primaryButton: {
+    minHeight: 40,
+    border: 0,
+    borderRadius: 999,
+    background: 'var(--color-accent)',
+    color: '#fff',
+    padding: '0 16px',
+    fontWeight: 700
+  },
+  ghostButton: {
+    minHeight: 40,
+    borderRadius: 999,
+    border: '1px solid rgba(30, 27, 22, 0.18)',
+    background: 'rgba(30, 27, 22, 0.04)',
+    color: 'var(--color-ink)',
+    padding: '0 16px',
+    fontWeight: 600
+  },
+  ghostButtonDisabled: {
+    minHeight: 40,
+    borderRadius: 999,
+    border: '1px solid rgba(30, 27, 22, 0.1)',
+    background: 'rgba(30, 27, 22, 0.02)',
+    color: 'var(--color-muted)',
+    padding: '0 16px',
+    fontWeight: 600
+  },
+  empty: {
+    margin: 0,
+    color: 'var(--color-muted)'
+  }
+} as const

--- a/src/renderer/features/categories-rules/RuleEditorPanel.tsx
+++ b/src/renderer/features/categories-rules/RuleEditorPanel.tsx
@@ -1,0 +1,290 @@
+import { useEffect, useState } from 'react'
+import type {
+  CategoryOption,
+  CreateCategorizationRuleInput,
+  RulePreviewInput,
+  UpdateCategorizationRuleInput,
+  CategorizationRuleSummary
+} from '../../../shared/contracts/categories'
+import type { TransactionNormalizedType, TransactionRuleSuggestion } from '../../../shared/contracts/transactions'
+
+interface RuleEditorPanelProps {
+  mode: 'create' | 'edit'
+  rule?: CategorizationRuleSummary
+  draft?: TransactionRuleSuggestion['draft']
+  categoryOptions: CategoryOption[]
+  onClose: () => void
+  onSave: (input: CreateCategorizationRuleInput | UpdateCategorizationRuleInput, previewAfterSave?: boolean) => void
+  onDelete: (ruleId: string) => void
+  onTest: (input: RulePreviewInput) => void
+  onPreviewApply: (input: CreateCategorizationRuleInput | UpdateCategorizationRuleInput) => void
+}
+
+const typeOptions: Array<{ value: TransactionNormalizedType; label: string }> = [
+  { value: 'expense', label: 'Expense' },
+  { value: 'income', label: 'Income' },
+  { value: 'transfer', label: 'Transfer' },
+  { value: 'refund', label: 'Refund' },
+  { value: 'atm-withdrawal', label: 'ATM withdrawal' },
+  { value: 'credit-card-payment', label: 'Credit card payment' }
+]
+
+export const RuleEditorPanel = ({
+  mode,
+  rule,
+  draft,
+  categoryOptions,
+  onClose,
+  onSave,
+  onDelete,
+  onTest,
+  onPreviewApply
+}: RuleEditorPanelProps) => {
+  const [name, setName] = useState('')
+  const [descriptionKeywords, setDescriptionKeywords] = useState('')
+  const [transactionType, setTransactionType] = useState<TransactionNormalizedType | ''>('')
+  const [direction, setDirection] = useState<'debit' | 'credit' | ''>('')
+  const [amountMin, setAmountMin] = useState('')
+  const [amountMax, setAmountMax] = useState('')
+  const [tags, setTags] = useState('')
+  const [categoryId, setCategoryId] = useState('')
+  const [actionType, setActionType] = useState<TransactionNormalizedType | ''>('')
+  const [appendTags, setAppendTags] = useState('')
+
+  useEffect(() => {
+    const source = rule
+      ? {
+          name: rule.name,
+          condition: rule.condition,
+          action: rule.action
+        }
+      : draft
+    setName(source?.name ?? '')
+    setDescriptionKeywords((source?.condition.descriptionContains ?? []).join(', '))
+    setTransactionType(source?.condition.transactionTypes[0] ?? '')
+    setDirection(source?.condition.directions[0] ?? '')
+    setAmountMin(source?.condition.amountMinMinor !== undefined ? String(source.condition.amountMinMinor / 100) : '')
+    setAmountMax(source?.condition.amountMaxMinor !== undefined ? String(source.condition.amountMaxMinor / 100) : '')
+    setTags((source?.condition.tags ?? []).join(', '))
+    setCategoryId(source?.action.categoryId ?? '')
+    setActionType(source?.action.type ?? '')
+    setAppendTags((source?.action.appendTags ?? []).join(', '))
+  }, [draft, rule])
+
+  const buildPayload = (): CreateCategorizationRuleInput | UpdateCategorizationRuleInput => {
+    const payload = {
+      name,
+      condition: {
+        descriptionContains: descriptionKeywords.split(',').map((item) => item.trim()).filter(Boolean),
+        amountMinMinor: amountMin ? Math.round(Number(amountMin) * 100) : undefined,
+        amountMaxMinor: amountMax ? Math.round(Number(amountMax) * 100) : undefined,
+        transactionTypes: transactionType ? [transactionType] : [],
+        tags: tags.split(',').map((item) => item.trim()).filter(Boolean),
+        directions: direction ? [direction] : []
+      },
+      action: {
+        categoryId: categoryId || undefined,
+        type: actionType || undefined,
+        appendTags: appendTags.split(',').map((item) => item.trim()).filter(Boolean)
+      }
+    }
+
+    return mode === 'edit'
+      ? {
+          ruleId: rule!.id,
+          ...payload
+        }
+      : payload
+  }
+
+  return (
+    <aside style={styles.panel}>
+      <div style={styles.header}>
+        <div>
+          <div style={styles.kicker}>{mode === 'create' ? 'New rule' : 'Edit rule'}</div>
+          <h3 style={styles.heading}>{mode === 'create' ? 'Create reusable rule' : rule?.name}</h3>
+        </div>
+        <button type="button" style={styles.secondaryButton} onClick={onClose}>
+          Close
+        </button>
+      </div>
+
+      <label style={styles.field}>
+        <span style={styles.label}>Rule name</span>
+        <input value={name} onChange={(event) => setName(event.target.value)} style={styles.input} />
+      </label>
+      <label style={styles.field}>
+        <span style={styles.label}>Description keywords</span>
+        <input value={descriptionKeywords} onChange={(event) => setDescriptionKeywords(event.target.value)} placeholder="burger, king" style={styles.input} />
+      </label>
+      <div style={styles.grid}>
+        <label style={styles.field}>
+          <span style={styles.label}>Transaction type</span>
+          <select value={transactionType} onChange={(event) => setTransactionType(event.target.value as TransactionNormalizedType | '')} style={styles.input}>
+            <option value="">Any</option>
+            {typeOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={styles.field}>
+          <span style={styles.label}>Direction</span>
+          <select value={direction} onChange={(event) => setDirection(event.target.value as 'debit' | 'credit' | '')} style={styles.input}>
+            <option value="">Any</option>
+            <option value="debit">Debit</option>
+            <option value="credit">Credit</option>
+          </select>
+        </label>
+      </div>
+      <div style={styles.grid}>
+        <label style={styles.field}>
+          <span style={styles.label}>Minimum amount</span>
+          <input value={amountMin} onChange={(event) => setAmountMin(event.target.value)} style={styles.input} />
+        </label>
+        <label style={styles.field}>
+          <span style={styles.label}>Maximum amount</span>
+          <input value={amountMax} onChange={(event) => setAmountMax(event.target.value)} style={styles.input} />
+        </label>
+      </div>
+      <label style={styles.field}>
+        <span style={styles.label}>Must already have tags</span>
+        <input value={tags} onChange={(event) => setTags(event.target.value)} placeholder="food, shared" style={styles.input} />
+      </label>
+      <label style={styles.field}>
+        <span style={styles.label}>Assign category</span>
+        <select value={categoryId} onChange={(event) => setCategoryId(event.target.value)} style={styles.input}>
+          <option value="">No category change</option>
+          {categoryOptions.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <div style={styles.grid}>
+        <label style={styles.field}>
+          <span style={styles.label}>Set transaction type</span>
+          <select value={actionType} onChange={(event) => setActionType(event.target.value as TransactionNormalizedType | '')} style={styles.input}>
+            <option value="">No type change</option>
+            {typeOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={styles.field}>
+          <span style={styles.label}>Append tags</span>
+          <input value={appendTags} onChange={(event) => setAppendTags(event.target.value)} placeholder="restaurant" style={styles.input} />
+        </label>
+      </div>
+
+      <div style={styles.actions}>
+        <button type="button" style={styles.secondaryButton} onClick={() => onTest(buildPayload())}>
+          Test rule
+        </button>
+        <button type="button" style={styles.secondaryButton} onClick={() => onPreviewApply(buildPayload())}>
+          Preview existing
+        </button>
+        <button type="button" style={styles.primaryButton} onClick={() => onSave(buildPayload())}>
+          Save rule
+        </button>
+      </div>
+
+      {mode === 'edit' && rule ? (
+        <div style={styles.actions}>
+          <button type="button" style={styles.destructiveButton} onClick={() => onDelete(rule.id)}>
+            Delete rule
+          </button>
+        </div>
+      ) : null}
+    </aside>
+  )
+}
+
+const styles = {
+  panel: {
+    position: 'fixed' as const,
+    top: 110,
+    right: 24,
+    bottom: 24,
+    width: 460,
+    display: 'grid',
+    gap: 'var(--space-md)',
+    padding: 'var(--space-lg)',
+    borderRadius: 'var(--radius-lg)',
+    border: '1px solid var(--color-border)',
+    background: 'rgba(245, 241, 232, 0.96)',
+    boxShadow: 'var(--shadow-panel)',
+    zIndex: 30,
+    overflowY: 'auto' as const
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: 'var(--space-md)'
+  },
+  kicker: {
+    fontSize: 14,
+    fontWeight: 600,
+    color: 'var(--color-accent)'
+  },
+  heading: {
+    margin: 'var(--space-xs) 0 0 0',
+    fontSize: 24
+  },
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+    gap: 'var(--space-sm)'
+  },
+  field: {
+    display: 'grid',
+    gap: 'var(--space-xs)'
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: 600
+  },
+  input: {
+    minHeight: 44,
+    borderRadius: 16,
+    border: '1px solid rgba(15, 118, 110, 0.18)',
+    background: 'rgba(255, 255, 255, 0.9)',
+    padding: '0 14px'
+  },
+  actions: {
+    display: 'flex',
+    gap: 'var(--space-sm)',
+    flexWrap: 'wrap' as const
+  },
+  secondaryButton: {
+    minHeight: 42,
+    borderRadius: 999,
+    border: '1px solid rgba(30, 27, 22, 0.18)',
+    background: 'rgba(30, 27, 22, 0.04)',
+    color: 'var(--color-ink)',
+    padding: '0 16px',
+    fontWeight: 600
+  },
+  primaryButton: {
+    minHeight: 42,
+    border: 0,
+    borderRadius: 999,
+    background: 'var(--color-accent)',
+    color: '#fff',
+    padding: '0 16px',
+    fontWeight: 700
+  },
+  destructiveButton: {
+    minHeight: 42,
+    borderRadius: 999,
+    border: '1px solid rgba(180, 35, 24, 0.24)',
+    background: 'rgba(180, 35, 24, 0.08)',
+    color: 'var(--color-destructive)',
+    padding: '0 16px',
+    fontWeight: 700
+  }
+} as const

--- a/src/renderer/features/categories-rules/RulePane.tsx
+++ b/src/renderer/features/categories-rules/RulePane.tsx
@@ -1,0 +1,175 @@
+import type { CategorizationRuleSummary } from '../../../shared/contracts/categories'
+
+interface RulePaneProps {
+  rules: CategorizationRuleSummary[]
+  onCreate: () => void
+  onEdit: (rule: CategorizationRuleSummary) => void
+  onToggle: (rule: CategorizationRuleSummary) => void
+}
+
+const summarizeCondition = (rule: CategorizationRuleSummary) => {
+  const parts = [
+    rule.condition.descriptionContains.length ? `contains ${rule.condition.descriptionContains.join(', ')}` : null,
+    rule.condition.transactionTypes.length ? `types: ${rule.condition.transactionTypes.join(', ')}` : null,
+    rule.condition.tags.length ? `tags: ${rule.condition.tags.join(', ')}` : null,
+    rule.condition.directions.length ? `direction: ${rule.condition.directions.join(', ')}` : null
+  ].filter(Boolean)
+  return parts.join(' • ') || 'Matches all imported transactions'
+}
+
+const summarizeAction = (rule: CategorizationRuleSummary) => {
+  const parts = [
+    rule.action.categoryId ? 'assign category' : null,
+    rule.action.type ? `set type to ${rule.action.type}` : null,
+    rule.action.appendTags.length ? `append ${rule.action.appendTags.join(', ')}` : null
+  ].filter(Boolean)
+  return parts.join(' • ') || 'No action'
+}
+
+export const RulePane = ({ rules, onCreate, onEdit, onToggle }: RulePaneProps) => (
+  <section style={styles.card}>
+    <div style={styles.header}>
+      <div>
+        <div style={styles.kicker}>Automation rules</div>
+        <h3 style={styles.heading}>Reusable categorization logic</h3>
+      </div>
+      <button type="button" style={styles.primaryButton} onClick={onCreate}>
+        Add rule
+      </button>
+    </div>
+
+    <div style={styles.list}>
+      {rules.map((rule) => (
+        <article key={rule.id} style={styles.row}>
+          <div style={styles.rowHeader}>
+            <strong>{rule.name}</strong>
+            <div style={styles.badges}>
+              {rule.kind === 'system' ? <span style={styles.systemBadge}>Starter</span> : null}
+              <span style={rule.isEnabled ? styles.enabledBadge : styles.disabledBadge}>{rule.isEnabled ? 'Enabled' : 'Disabled'}</span>
+            </div>
+          </div>
+          <div style={styles.summaryLine}>{summarizeCondition(rule)}</div>
+          <div style={styles.summaryLine}>{summarizeAction(rule)}</div>
+          <div style={styles.rowFooter}>
+            <span>{rule.affectedTransactionCount} affected transactions</span>
+            <div style={styles.footerActions}>
+              <button type="button" style={styles.ghostButton} onClick={() => onToggle(rule)}>
+                {rule.isEnabled ? 'Disable' : 'Enable'}
+              </button>
+              <button type="button" style={styles.ghostButton} onClick={() => onEdit(rule)}>
+                Manage
+              </button>
+            </div>
+          </div>
+        </article>
+      ))}
+    </div>
+  </section>
+)
+
+const styles = {
+  card: {
+    display: 'grid',
+    gap: 'var(--space-md)',
+    padding: 'var(--space-lg)',
+    borderRadius: 'var(--radius-lg)',
+    border: '1px solid var(--color-border)',
+    background: 'rgba(245, 241, 232, 0.72)',
+    boxShadow: 'var(--shadow-panel)'
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: 'var(--space-md)'
+  },
+  kicker: {
+    fontSize: 14,
+    fontWeight: 600,
+    color: 'var(--color-accent)'
+  },
+  heading: {
+    margin: 'var(--space-xs) 0 0 0',
+    fontSize: 22
+  },
+  list: {
+    display: 'grid',
+    gap: 'var(--space-sm)'
+  },
+  row: {
+    display: 'grid',
+    gap: 'var(--space-xs)',
+    padding: 'var(--space-md)',
+    borderRadius: 18,
+    background: 'rgba(255, 255, 255, 0.56)',
+    border: '1px solid rgba(30, 27, 22, 0.08)'
+  },
+  rowHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: 'var(--space-sm)',
+    alignItems: 'center'
+  },
+  rowFooter: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: 'var(--space-sm)',
+    alignItems: 'center',
+    color: 'var(--color-muted)',
+    fontSize: 14
+  },
+  summaryLine: {
+    color: 'var(--color-muted)',
+    fontSize: 14
+  },
+  badges: {
+    display: 'flex',
+    gap: 'var(--space-xs)',
+    flexWrap: 'wrap' as const
+  },
+  systemBadge: {
+    padding: '4px 10px',
+    borderRadius: 999,
+    background: 'rgba(15, 118, 110, 0.1)',
+    color: 'var(--color-accent)',
+    fontSize: 12,
+    fontWeight: 700
+  },
+  enabledBadge: {
+    padding: '4px 10px',
+    borderRadius: 999,
+    background: 'rgba(15, 118, 110, 0.1)',
+    color: 'var(--color-accent)',
+    fontSize: 12,
+    fontWeight: 700
+  },
+  disabledBadge: {
+    padding: '4px 10px',
+    borderRadius: 999,
+    background: 'rgba(30, 27, 22, 0.06)',
+    color: 'var(--color-muted)',
+    fontSize: 12,
+    fontWeight: 700
+  },
+  footerActions: {
+    display: 'flex',
+    gap: 'var(--space-xs)'
+  },
+  primaryButton: {
+    minHeight: 40,
+    border: 0,
+    borderRadius: 999,
+    background: 'var(--color-accent)',
+    color: '#fff',
+    padding: '0 16px',
+    fontWeight: 700
+  },
+  ghostButton: {
+    minHeight: 38,
+    borderRadius: 999,
+    border: '1px solid rgba(30, 27, 22, 0.18)',
+    background: 'rgba(30, 27, 22, 0.04)',
+    color: 'var(--color-ink)',
+    padding: '0 14px',
+    fontWeight: 600
+  }
+} as const

--- a/src/renderer/features/categories-rules/RulePreviewPanel.tsx
+++ b/src/renderer/features/categories-rules/RulePreviewPanel.tsx
@@ -1,0 +1,143 @@
+import type { RuleApplyPreview } from '../../../shared/contracts/categories'
+
+interface RulePreviewPanelProps {
+  preview: RuleApplyPreview
+  onClose: () => void
+  onApply?: () => void
+}
+
+const formatAmount = (minor: number) =>
+  new Intl.NumberFormat('en-IN', {
+    style: 'currency',
+    currency: 'INR',
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2
+  }).format(minor / 100)
+
+export const RulePreviewPanel = ({ preview, onClose, onApply }: RulePreviewPanelProps) => (
+  <aside style={styles.panel}>
+    <div style={styles.header}>
+      <div>
+        <div style={styles.kicker}>Preview-first apply</div>
+        <h3 style={styles.heading}>Review affected transactions</h3>
+      </div>
+      <button type="button" style={styles.secondaryButton} onClick={onClose}>
+        Close
+      </button>
+    </div>
+
+    <div style={styles.summaryCard}>
+      <strong>{preview.matchCount} matching transactions</strong>
+      <span style={styles.helper}>Walnut shows a sample list before applying the rule to existing history.</span>
+    </div>
+
+    <div style={styles.sampleList}>
+      {preview.samples.map((sample) => (
+        <div key={sample.transactionId} style={styles.sampleRow}>
+          <div>
+            <strong>{sample.description}</strong>
+            <div style={styles.helper}>{sample.transactionDateRaw}</div>
+          </div>
+          <div style={styles.sampleMeta}>
+            <span>{formatAmount(sample.signedAmountMinor)}</span>
+            <span>{sample.nextCategoryPath?.join(' > ') ?? 'No category change'}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+
+    {onApply ? (
+      <div style={styles.actions}>
+        <button type="button" style={styles.primaryButton} onClick={onApply}>
+          Apply to existing transactions
+        </button>
+      </div>
+    ) : null}
+  </aside>
+)
+
+const styles = {
+  panel: {
+    position: 'fixed' as const,
+    left: 120,
+    right: 120,
+    bottom: 24,
+    display: 'grid',
+    gap: 'var(--space-md)',
+    padding: 'var(--space-lg)',
+    borderRadius: 'var(--radius-lg)',
+    border: '1px solid var(--color-border)',
+    background: 'rgba(245, 241, 232, 0.98)',
+    boxShadow: 'var(--shadow-panel)',
+    zIndex: 35
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: 'var(--space-md)'
+  },
+  kicker: {
+    fontSize: 14,
+    fontWeight: 600,
+    color: 'var(--color-accent)'
+  },
+  heading: {
+    margin: 'var(--space-xs) 0 0 0',
+    fontSize: 24
+  },
+  summaryCard: {
+    display: 'grid',
+    gap: 'var(--space-xs)',
+    padding: 'var(--space-md)',
+    borderRadius: 18,
+    background: 'rgba(255, 255, 255, 0.56)'
+  },
+  sampleList: {
+    display: 'grid',
+    gap: 'var(--space-sm)',
+    maxHeight: 260,
+    overflowY: 'auto' as const
+  },
+  sampleRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: 'var(--space-md)',
+    padding: 'var(--space-md)',
+    borderRadius: 18,
+    background: 'rgba(255, 255, 255, 0.56)',
+    border: '1px solid rgba(30, 27, 22, 0.08)'
+  },
+  sampleMeta: {
+    display: 'grid',
+    justifyItems: 'end',
+    gap: 'var(--space-xs)',
+    color: 'var(--color-muted)',
+    fontSize: 14
+  },
+  helper: {
+    color: 'var(--color-muted)',
+    fontSize: 14
+  },
+  actions: {
+    display: 'flex',
+    justifyContent: 'flex-end'
+  },
+  secondaryButton: {
+    minHeight: 42,
+    borderRadius: 999,
+    border: '1px solid rgba(30, 27, 22, 0.18)',
+    background: 'rgba(30, 27, 22, 0.04)',
+    color: 'var(--color-ink)',
+    padding: '0 16px',
+    fontWeight: 600
+  },
+  primaryButton: {
+    minHeight: 42,
+    border: 0,
+    borderRadius: 999,
+    background: 'var(--color-accent)',
+    color: '#fff',
+    padding: '0 18px',
+    fontWeight: 700
+  }
+} as const

--- a/src/renderer/features/transactions/TransactionDetailDrawer.tsx
+++ b/src/renderer/features/transactions/TransactionDetailDrawer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import type { CategoryTreeNode } from '../../../shared/contracts/categories'
 import type { TransactionDetail, TransactionNormalizedType, TransactionReviewState, TransactionRuleSuggestion, UpdateTransactionInput } from '../../../shared/contracts/transactions'
 
 interface TransactionDetailDrawerProps {
@@ -7,6 +8,7 @@ interface TransactionDetailDrawerProps {
   ruleSuggestion?: TransactionRuleSuggestion
   onClose: () => void
   onSave: (input: UpdateTransactionInput) => void
+  onUseRuleSuggestion?: (suggestion: TransactionRuleSuggestion) => void
 }
 
 const typeOptions: Array<{ value: TransactionNormalizedType; label: string }> = [
@@ -28,15 +30,35 @@ const formatAmountInput = (minor: number) => String(minor / 100)
 const formatCurrency = (minor?: number) =>
   minor === undefined ? 'Unavailable' : new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR' }).format(minor / 100)
 
-export const TransactionDetailDrawer = ({ detail, saving, ruleSuggestion, onClose, onSave }: TransactionDetailDrawerProps) => {
+const flattenCategories = (nodes: CategoryTreeNode[]): Array<{ id: string; label: string }> =>
+  nodes.flatMap((node) => [
+    { id: node.id, label: node.path.join(' > ') },
+    ...flattenCategories(node.children)
+  ])
+
+export const TransactionDetailDrawer = ({ detail, saving, ruleSuggestion, onClose, onSave, onUseRuleSuggestion }: TransactionDetailDrawerProps) => {
   const [transactionDateRaw, setTransactionDateRaw] = useState('')
   const [description, setDescription] = useState('')
   const [signedAmount, setSignedAmount] = useState('')
   const [normalizedType, setNormalizedType] = useState<TransactionNormalizedType>('expense')
-  const [category, setCategory] = useState('')
+  const [categoryId, setCategoryId] = useState('')
   const [reference, setReference] = useState('')
   const [tags, setTags] = useState('')
   const [reviewStateOverride, setReviewStateOverride] = useState<TransactionReviewState | ''>('')
+  const [categoryOptions, setCategoryOptions] = useState<Array<{ id: string; label: string }>>([])
+
+  useEffect(() => {
+    let cancelled = false
+    void window.walnut.listCategories().then((categories) => {
+      if (!cancelled) {
+        setCategoryOptions(flattenCategories(categories))
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
     if (!detail) {
@@ -47,7 +69,7 @@ export const TransactionDetailDrawer = ({ detail, saving, ruleSuggestion, onClos
     setDescription(detail.description)
     setSignedAmount(formatAmountInput(detail.signedAmountMinor))
     setNormalizedType(detail.normalizedType)
-    setCategory(detail.category ?? '')
+    setCategoryId(detail.categoryId ?? '')
     setReference(detail.reference ?? '')
     setTags(detail.tags.join(', '))
     setReviewStateOverride(detail.reviewStateOverride ?? '')
@@ -95,7 +117,11 @@ export const TransactionDetailDrawer = ({ detail, saving, ruleSuggestion, onClos
             description,
             signedAmountMinor: Math.round(Number(signedAmount || '0') * 100),
             normalizedType,
-            category: category.trim() ? category.trim() : null,
+            categoryId: categoryId || null,
+            category:
+              categoryId
+                ? categoryOptions.find((option) => option.id === categoryId)?.label ?? null
+                : null,
             reference: reference.trim() ? reference.trim() : null,
             tags: tags.split(',').map((tag) => tag.trim()).filter(Boolean),
             reviewStateOverride: reviewStateOverride || null
@@ -130,7 +156,14 @@ export const TransactionDetailDrawer = ({ detail, saving, ruleSuggestion, onClos
 
         <label style={styles.field}>
           <span style={styles.label}>Category</span>
-          <input type="text" value={category} onChange={(event) => setCategory(event.target.value)} placeholder="Optional category" style={styles.input} />
+          <select aria-label="Category" value={categoryId} onChange={(event) => setCategoryId(event.target.value)} style={styles.input}>
+            <option value="">No category</option>
+            {categoryOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
         </label>
 
         <label style={styles.field}>
@@ -159,6 +192,13 @@ export const TransactionDetailDrawer = ({ detail, saving, ruleSuggestion, onClos
             <div style={styles.kicker}>Rule suggestion</div>
             <strong>{ruleSuggestion.title}</strong>
             <p style={styles.helper}>{ruleSuggestion.description}</p>
+            {onUseRuleSuggestion ? (
+              <div style={styles.actions}>
+                <button type="button" style={styles.secondaryButton} onClick={() => onUseRuleSuggestion(ruleSuggestion)}>
+                  Create reusable rule
+                </button>
+              </div>
+            ) : null}
           </div>
         ) : null}
 
@@ -260,6 +300,15 @@ const styles = {
   },
   closeButton: {
     minHeight: 40,
+    borderRadius: 999,
+    border: '1px solid rgba(30, 27, 22, 0.18)',
+    background: 'rgba(30, 27, 22, 0.04)',
+    color: 'var(--color-ink)',
+    padding: '0 16px',
+    fontWeight: 600
+  },
+  secondaryButton: {
+    minHeight: 42,
     borderRadius: 999,
     border: '1px solid rgba(30, 27, 22, 0.18)',
     background: 'rgba(30, 27, 22, 0.04)',

--- a/src/renderer/features/transactions/TransactionsScreen.tsx
+++ b/src/renderer/features/transactions/TransactionsScreen.tsx
@@ -21,7 +21,11 @@ const formatAmount = (minor: number) =>
     minimumFractionDigits: 2
   }).format(minor / 100)
 
-export const TransactionsScreen = () => {
+interface TransactionsScreenProps {
+  onUseRuleSuggestion?: (suggestion: TransactionRuleSuggestion) => void
+}
+
+export const TransactionsScreen = ({ onUseRuleSuggestion }: TransactionsScreenProps) => {
   const [pendingSearch, setPendingSearch] = useState('')
   const [submittedSearch, setSubmittedSearch] = useState('')
   const [filters, setFilters] = useState<TransactionLedgerQuery>({})
@@ -298,6 +302,7 @@ export const TransactionsScreen = () => {
             detail={detailLoading ? undefined : detail}
             saving={saving}
             ruleSuggestion={ruleSuggestion}
+            onUseRuleSuggestion={onUseRuleSuggestion}
             onClose={() => {
               setActiveTransactionId(undefined)
               setDetail(undefined)

--- a/src/renderer/mockWalnutApi.ts
+++ b/src/renderer/mockWalnutApi.ts
@@ -7,6 +7,22 @@ import type {
 } from '../shared/contracts/app-state'
 import type { AccountProfileDraft } from '../shared/contracts/account'
 import type {
+  ApplyRuleToExistingInput,
+  CategoryTreeNode,
+  CategorizationRuleSummary,
+  CreateCategoryInput,
+  CreateCategorizationRuleInput,
+  DeleteCategoryInput,
+  DeleteCategorizationRuleInput,
+  MergeCategoryInput,
+  RuleApplyPreview,
+  RulePreviewInput,
+  RuleTestPreview,
+  ToggleCategorizationRuleInput,
+  UpdateCategoryInput,
+  UpdateCategorizationRuleInput
+} from '../shared/contracts/categories'
+import type {
   ChooseImportSheetInput,
   CommitImportBatchInput,
   GetImportBatchDetailInput,
@@ -51,6 +67,8 @@ const RESOLVED_REVIEW_ITEMS_KEY = 'walnut.mock.resolved-review-items'
 const DEVICE_PROFILES_KEY = 'walnut.mock.device-profiles'
 const ACTIVE_PROFILE_KEY = 'walnut.mock.active-profile-id'
 const PROFILE_SNAPSHOTS_KEY = 'walnut.mock.profile-snapshots'
+const CATEGORIES_KEY = 'walnut.mock.categories'
+const RULES_KEY = 'walnut.mock.rules'
 
 type StoredState = AppShellState & {
   mockPin?: string
@@ -61,6 +79,57 @@ type StoredState = AppShellState & {
 type MockWalnutApi = WalnutApi & {
   __mock: true
 }
+
+const defaultCategories = (): CategoryTreeNode[] => [
+  {
+    id: 'cat:food-dining',
+    name: 'Food & Dining',
+    kind: 'system',
+    path: ['Food & Dining'],
+    isActive: true,
+    isIncomeCategory: false,
+    sortOrder: 10,
+    counts: { directTransactionCount: 0, totalTransactionCount: 0 },
+    children: []
+  },
+  {
+    id: 'cat:income',
+    name: 'Income',
+    kind: 'system',
+    path: ['Income'],
+    isActive: true,
+    isIncomeCategory: true,
+    sortOrder: 160,
+    counts: { directTransactionCount: 0, totalTransactionCount: 0 },
+    children: [
+      {
+        id: 'cat:income-salary',
+        name: 'Salary',
+        kind: 'system',
+        parentId: 'cat:income',
+        path: ['Income', 'Salary'],
+        isActive: true,
+        isIncomeCategory: true,
+        sortOrder: 161,
+        counts: { directTransactionCount: 0, totalTransactionCount: 0 },
+        children: []
+      }
+    ]
+  },
+  {
+    id: 'cat:uncategorized',
+    name: 'Uncategorized',
+    kind: 'system',
+    path: ['Uncategorized'],
+    isActive: true,
+    isIncomeCategory: false,
+    sortOrder: 190,
+    counts: { directTransactionCount: 0, totalTransactionCount: 0 },
+    children: []
+  }
+]
+
+const defaultRules = (): CategorizationRuleSummary[] => []
 
 const defaultState = (): StoredState => ({
   currentView: 'onboarding',
@@ -199,6 +268,26 @@ const writeProfileSnapshots = (snapshots: Record<string, ProfileSnapshot>) => {
   return snapshots
 }
 
+const readCategories = (): CategoryTreeNode[] => {
+  const raw = window.localStorage.getItem(CATEGORIES_KEY)
+  return raw ? (JSON.parse(raw) as CategoryTreeNode[]) : defaultCategories()
+}
+
+const writeCategories = (categories: CategoryTreeNode[]) => {
+  window.localStorage.setItem(CATEGORIES_KEY, JSON.stringify(categories))
+  return categories
+}
+
+const readRules = (): CategorizationRuleSummary[] => {
+  const raw = window.localStorage.getItem(RULES_KEY)
+  return raw ? (JSON.parse(raw) as CategorizationRuleSummary[]) : defaultRules()
+}
+
+const writeRules = (rules: CategorizationRuleSummary[]) => {
+  window.localStorage.setItem(RULES_KEY, JSON.stringify(rules))
+  return rules
+}
+
 const syncHistorySummary = (batchId: string, detail: ImportBatchDetail) => {
   const history = readImportHistory().map((row) =>
     row.batchId === batchId
@@ -316,6 +405,8 @@ const flattenTransactions = (): TransactionDetail[] => {
             transaction.reference,
             transaction.direction
           ),
+          categoryId: (transaction as typeof transaction & { categoryId?: string }).categoryId,
+          categoryPath: (transaction as typeof transaction & { categoryPath?: string[] }).categoryPath,
           category: (transaction as typeof transaction & { category?: string }).category,
           tags: transaction.tags ?? [],
           reference: transaction.reference,
@@ -1202,10 +1293,116 @@ export const createMockWalnutApi = (): MockWalnutApi => ({
               fromType: previousType,
               toType: input.normalizedType,
               title: 'Create a rule from this type change later',
-              description: 'Walnut can use this correction as a suggestion when reusable rules are introduced.'
+              description: 'Walnut can use this correction as a suggestion when reusable rules are introduced.',
+              draft: {
+                name: `${updatedDetail.description} rule`,
+                condition: {
+                  descriptionContains: updatedDetail.description
+                    .split(/\s+/)
+                    .map((token) => token.trim().toLowerCase())
+                    .filter((token) => token.length >= 3)
+                    .slice(0, 3),
+                  transactionTypes: [previousType],
+                  tags: updatedDetail.tags,
+                  directions: [updatedDetail.direction]
+                },
+                action: {
+                  categoryId: updatedDetail.categoryId,
+                  type: input.normalizedType,
+                  appendTags: updatedDetail.tags
+                }
+              }
             }
           : undefined
     }
+  },
+  async listCategories() {
+    return readCategories()
+  },
+  async createCategory(input: CreateCategoryInput) {
+    const next: CategoryTreeNode = {
+      id: crypto.randomUUID(),
+      name: input.name.trim(),
+      kind: 'user',
+      parentId: input.parentId,
+      path: input.parentId ? ['Parent', input.name.trim()] : [input.name.trim()],
+      isActive: true,
+      isIncomeCategory: Boolean(input.isIncomeCategory),
+      sortOrder: Date.now(),
+      counts: { directTransactionCount: 0, totalTransactionCount: 0 },
+      children: []
+    }
+    return writeCategories([...readCategories(), next])
+  },
+  async updateCategory(input: UpdateCategoryInput) {
+    return writeCategories(
+      readCategories().map((category) =>
+        category.id === input.categoryId
+          ? {
+              ...category,
+              name: input.name ?? category.name,
+              parentId: input.parentId === undefined ? category.parentId : input.parentId ?? undefined,
+              isActive: input.isActive ?? category.isActive
+            }
+          : category
+      )
+    )
+  },
+  async mergeCategory(input: MergeCategoryInput) {
+    return writeCategories(readCategories().filter((category) => category.id !== input.sourceCategoryId))
+  },
+  async deleteCategory(input: DeleteCategoryInput) {
+    return writeCategories(readCategories().filter((category) => category.id !== input.categoryId))
+  },
+  async listRules() {
+    return readRules()
+  },
+  async createRule(input: CreateCategorizationRuleInput) {
+    return writeRules([
+      ...readRules(),
+      {
+        id: crypto.randomUUID(),
+        name: input.name,
+        kind: 'user',
+        isEnabled: true,
+        condition: input.condition,
+        action: input.action,
+        specificityScore: 1,
+        affectedTransactionCount: 0,
+        updatedAt: new Date().toISOString()
+      }
+    ])
+  },
+  async updateRule(input: UpdateCategorizationRuleInput) {
+    return writeRules(
+      readRules().map((rule) =>
+        rule.id === input.ruleId
+          ? {
+              ...rule,
+              name: input.name ?? rule.name,
+              condition: input.condition ?? rule.condition,
+              action: input.action ?? rule.action,
+              isEnabled: input.isEnabled ?? rule.isEnabled,
+              updatedAt: new Date().toISOString()
+            }
+          : rule
+      )
+    )
+  },
+  async toggleRule(input: ToggleCategorizationRuleInput) {
+    return writeRules(readRules().map((rule) => (rule.id === input.ruleId ? { ...rule, isEnabled: input.isEnabled } : rule)))
+  },
+  async deleteRule(input: DeleteCategorizationRuleInput) {
+    return writeRules(readRules().filter((rule) => rule.id !== input.ruleId))
+  },
+  async testRule(_input: RulePreviewInput): Promise<RuleTestPreview> {
+    return { matchCount: 0, samples: [] }
+  },
+  async previewRuleApplyToExisting(_input: RulePreviewInput | ApplyRuleToExistingInput): Promise<RuleApplyPreview> {
+    return { matchCount: 0, samples: [] }
+  },
+  async applyRuleToExisting(_input: ApplyRuleToExistingInput) {
+    return readRules()
   },
   async ping() {
     return 'pong'

--- a/src/shared/contracts/app-state.ts
+++ b/src/shared/contracts/app-state.ts
@@ -24,6 +24,22 @@ import type {
   UnlockResult
 } from './security'
 import type {
+  ApplyRuleToExistingInput,
+  CategorizationRuleSummary,
+  CreateCategoryInput,
+  CreateCategorizationRuleInput,
+  DeleteCategoryInput,
+  DeleteCategorizationRuleInput,
+  MergeCategoryInput,
+  RuleApplyPreview,
+  RulePreviewInput,
+  RuleTestPreview,
+  ToggleCategorizationRuleInput,
+  UpdateCategoryInput,
+  UpdateCategorizationRuleInput,
+  CategoryTreeNode
+} from './categories'
+import type {
   GetTransactionDetailInput,
   TransactionDetail,
   TransactionLedgerQuery,
@@ -121,5 +137,18 @@ export interface WalnutApi {
   listTransactions: (input?: TransactionLedgerQuery) => Promise<TransactionLedgerRow[]>
   getTransactionDetail: (input: GetTransactionDetailInput) => Promise<TransactionDetail>
   updateTransaction: (input: UpdateTransactionInput) => Promise<UpdateTransactionResult>
+  listCategories: () => Promise<CategoryTreeNode[]>
+  createCategory: (input: CreateCategoryInput) => Promise<CategoryTreeNode[]>
+  updateCategory: (input: UpdateCategoryInput) => Promise<CategoryTreeNode[]>
+  mergeCategory: (input: MergeCategoryInput) => Promise<CategoryTreeNode[]>
+  deleteCategory: (input: DeleteCategoryInput) => Promise<CategoryTreeNode[]>
+  listRules: () => Promise<CategorizationRuleSummary[]>
+  createRule: (input: CreateCategorizationRuleInput) => Promise<CategorizationRuleSummary[]>
+  updateRule: (input: UpdateCategorizationRuleInput) => Promise<CategorizationRuleSummary[]>
+  toggleRule: (input: ToggleCategorizationRuleInput) => Promise<CategorizationRuleSummary[]>
+  deleteRule: (input: DeleteCategorizationRuleInput) => Promise<CategorizationRuleSummary[]>
+  testRule: (input: RulePreviewInput) => Promise<RuleTestPreview>
+  previewRuleApplyToExisting: (input: RulePreviewInput | ApplyRuleToExistingInput) => Promise<RuleApplyPreview>
+  applyRuleToExisting: (input: ApplyRuleToExistingInput) => Promise<CategorizationRuleSummary[]>
   ping: () => Promise<string>
 }

--- a/src/shared/contracts/categories.ts
+++ b/src/shared/contracts/categories.ts
@@ -1,0 +1,175 @@
+import { z } from 'zod'
+import { TransactionNormalizedTypeSchema } from './transactions'
+
+export const CategoryKindSchema = z.enum(['system', 'user'])
+export const CategoryDirectionSchema = z.enum(['debit', 'credit'])
+
+export const CategoryCountSummarySchema = z.object({
+  directTransactionCount: z.number().int().nonnegative(),
+  totalTransactionCount: z.number().int().nonnegative()
+})
+
+export const CategoryTreeNodeSchema: z.ZodType<{
+  id: string
+  name: string
+  kind: 'system' | 'user'
+  parentId?: string
+  path: string[]
+  isActive: boolean
+  isIncomeCategory: boolean
+  sortOrder: number
+  counts: { directTransactionCount: number; totalTransactionCount: number }
+  children: Array<unknown>
+}> = z.lazy(() =>
+  z.object({
+    id: z.string(),
+    name: z.string(),
+    kind: CategoryKindSchema,
+    parentId: z.string().optional(),
+    path: z.array(z.string()),
+    isActive: z.boolean(),
+    isIncomeCategory: z.boolean(),
+    sortOrder: z.number().int(),
+    counts: CategoryCountSummarySchema,
+    children: z.array(CategoryTreeNodeSchema)
+  })
+)
+
+export const CategoryOptionSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  path: z.array(z.string()),
+  kind: CategoryKindSchema,
+  isActive: z.boolean()
+})
+
+export const CreateCategoryInputSchema = z.object({
+  name: z.string().trim().min(1),
+  parentId: z.string().optional(),
+  isIncomeCategory: z.boolean().optional()
+})
+
+export const UpdateCategoryInputSchema = z.object({
+  categoryId: z.string(),
+  name: z.string().trim().min(1).optional(),
+  parentId: z.string().nullable().optional(),
+  isActive: z.boolean().optional()
+})
+
+export const MergeCategoryInputSchema = z.object({
+  sourceCategoryId: z.string(),
+  targetCategoryId: z.string()
+})
+
+export const DeleteCategoryInputSchema = z.object({
+  categoryId: z.string()
+})
+
+export const CategorizationRuleConditionSchema = z.object({
+  descriptionContains: z.array(z.string().trim().min(1)).default([]),
+  amountMinMinor: z.number().optional(),
+  amountMaxMinor: z.number().optional(),
+  transactionTypes: z.array(TransactionNormalizedTypeSchema).default([]),
+  tags: z.array(z.string().trim().min(1)).default([]),
+  directions: z.array(CategoryDirectionSchema).default([])
+})
+
+export const CategorizationRuleActionSchema = z.object({
+  categoryId: z.string().optional(),
+  type: TransactionNormalizedTypeSchema.optional(),
+  appendTags: z.array(z.string().trim().min(1)).default([])
+})
+
+export const RuleCountSummarySchema = z.object({
+  affectedTransactionCount: z.number().int().nonnegative()
+})
+
+export const CategorizationRuleSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  kind: CategoryKindSchema,
+  isEnabled: z.boolean(),
+  condition: CategorizationRuleConditionSchema,
+  action: CategorizationRuleActionSchema,
+  specificityScore: z.number().int().nonnegative(),
+  affectedTransactionCount: z.number().int().nonnegative(),
+  updatedAt: z.string()
+})
+
+export const RulePreviewSampleSchema = z.object({
+  transactionId: z.string(),
+  transactionDateRaw: z.string(),
+  description: z.string(),
+  signedAmountMinor: z.number(),
+  currentCategoryPath: z.array(z.string()).optional(),
+  nextCategoryPath: z.array(z.string()).optional(),
+  currentType: TransactionNormalizedTypeSchema,
+  nextType: TransactionNormalizedTypeSchema,
+  tags: z.array(z.string())
+})
+
+export const RuleTestPreviewSchema = z.object({
+  matchCount: z.number().int().nonnegative(),
+  samples: z.array(RulePreviewSampleSchema)
+})
+
+export const RuleApplyPreviewSchema = z.object({
+  matchCount: z.number().int().nonnegative(),
+  samples: z.array(RulePreviewSampleSchema)
+})
+
+export const CreateCategorizationRuleInputSchema = z.object({
+  name: z.string().trim().min(1),
+  condition: CategorizationRuleConditionSchema,
+  action: CategorizationRuleActionSchema,
+  applyToExisting: z.boolean().optional()
+})
+
+export const UpdateCategorizationRuleInputSchema = z.object({
+  ruleId: z.string(),
+  name: z.string().trim().min(1).optional(),
+  condition: CategorizationRuleConditionSchema.optional(),
+  action: CategorizationRuleActionSchema.optional(),
+  isEnabled: z.boolean().optional()
+})
+
+export const ToggleCategorizationRuleInputSchema = z.object({
+  ruleId: z.string(),
+  isEnabled: z.boolean()
+})
+
+export const DeleteCategorizationRuleInputSchema = z.object({
+  ruleId: z.string()
+})
+
+export const RulePreviewInputSchema = z.object({
+  condition: CategorizationRuleConditionSchema,
+  action: CategorizationRuleActionSchema,
+  excludeRuleId: z.string().optional()
+})
+
+export const ApplyRuleToExistingInputSchema = z.object({
+  ruleId: z.string()
+})
+
+export type CategoryKind = z.infer<typeof CategoryKindSchema>
+export type CategoryDirection = z.infer<typeof CategoryDirectionSchema>
+export type CategoryCountSummary = z.infer<typeof CategoryCountSummarySchema>
+export type CategoryTreeNode = z.infer<typeof CategoryTreeNodeSchema>
+export type CategoryOption = z.infer<typeof CategoryOptionSchema>
+export type CreateCategoryInput = z.infer<typeof CreateCategoryInputSchema>
+export type UpdateCategoryInput = z.infer<typeof UpdateCategoryInputSchema>
+export type MergeCategoryInput = z.infer<typeof MergeCategoryInputSchema>
+export type DeleteCategoryInput = z.infer<typeof DeleteCategoryInputSchema>
+export type CategorizationRuleCondition = z.infer<typeof CategorizationRuleConditionSchema>
+export type CategorizationRuleAction = z.infer<typeof CategorizationRuleActionSchema>
+export type CategorizationRuleSummary = z.infer<typeof CategorizationRuleSummarySchema>
+export type RulePreviewSample = z.infer<typeof RulePreviewSampleSchema>
+export type RuleTestPreview = z.infer<typeof RuleTestPreviewSchema>
+export type RuleApplyPreview = z.infer<typeof RuleApplyPreviewSchema>
+export type CreateCategorizationRuleInput = z.infer<typeof CreateCategorizationRuleInputSchema>
+export type UpdateCategorizationRuleInput = z.infer<typeof UpdateCategorizationRuleInputSchema>
+export type ToggleCategorizationRuleInput = z.infer<typeof ToggleCategorizationRuleInputSchema>
+export type DeleteCategorizationRuleInput = z.infer<typeof DeleteCategorizationRuleInputSchema>
+export type RulePreviewInput = z.infer<typeof RulePreviewInputSchema>
+export type ApplyRuleToExistingInput = z.infer<typeof ApplyRuleToExistingInputSchema>

--- a/src/shared/contracts/transactions.ts
+++ b/src/shared/contracts/transactions.ts
@@ -12,11 +12,27 @@ export const TransactionNormalizedTypeSchema = z.enum([
 export const TransactionReviewStateSchema = z.enum(['clean', 'pending-review'])
 
 export const TransactionRuleSuggestionSchema = z.object({
-  field: z.literal('type'),
-  fromType: TransactionNormalizedTypeSchema,
-  toType: TransactionNormalizedTypeSchema,
+  field: z.enum(['type', 'category']),
+  fromType: TransactionNormalizedTypeSchema.optional(),
+  toType: TransactionNormalizedTypeSchema.optional(),
   title: z.string(),
-  description: z.string()
+  description: z.string(),
+  draft: z.object({
+    name: z.string(),
+    condition: z.object({
+      descriptionContains: z.array(z.string()),
+      amountMinMinor: z.number().optional(),
+      amountMaxMinor: z.number().optional(),
+      transactionTypes: z.array(TransactionNormalizedTypeSchema),
+      tags: z.array(z.string()),
+      directions: z.array(z.enum(['debit', 'credit']))
+    }),
+    action: z.object({
+      categoryId: z.string().optional(),
+      type: TransactionNormalizedTypeSchema.optional(),
+      appendTags: z.array(z.string())
+    })
+  })
 })
 
 export const TransactionLedgerRowSchema = z.object({
@@ -32,6 +48,8 @@ export const TransactionLedgerRowSchema = z.object({
   runningBalanceMinor: z.number().optional(),
   normalizedType: TransactionNormalizedTypeSchema,
   tags: z.array(z.string()),
+  categoryId: z.string().optional(),
+  categoryPath: z.array(z.string()).optional(),
   category: z.string().optional(),
   reference: z.string().optional(),
   reviewState: TransactionReviewStateSchema
@@ -60,6 +78,7 @@ export const UpdateTransactionInputSchema = z.object({
   signedAmountMinor: z.number().optional(),
   normalizedType: TransactionNormalizedTypeSchema.optional(),
   tags: z.array(z.string()).optional(),
+  categoryId: z.string().nullable().optional(),
   category: z.string().nullable().optional(),
   reference: z.string().nullable().optional(),
   reviewStateOverride: TransactionReviewStateSchema.nullable().optional()
@@ -79,6 +98,8 @@ export const TransactionDetailSchema = z.object({
   description: z.string(),
   signedAmountMinor: z.number(),
   normalizedType: TransactionNormalizedTypeSchema,
+  categoryId: z.string().optional(),
+  categoryPath: z.array(z.string()).optional(),
   category: z.string().optional(),
   tags: z.array(z.string()),
   reference: z.string().optional(),

--- a/tests/e2e/categories-rules.spec.ts
+++ b/tests/e2e/categories-rules.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test'
+
+const dashboardState = {
+  currentView: 'dashboard',
+  onboarding: {
+    currentStep: 'finish',
+    completedSteps: ['welcome', 'household-profile', 'pin-setup', 'recovery-key', 'account-profile', 'finish'],
+    recoveryConfirmed: true,
+    recoverySavedToDevice: true,
+    profile: {
+      householdName: 'Walnut Home',
+      ownerName: 'Bit'
+    }
+  },
+  security: {
+    failedAttempts: 0,
+    isLocked: false
+  },
+  dashboard: {
+    heading: 'Ready for your first import',
+    body: 'Add your first ICICI statement to create the account timeline and unlock dashboard insights.',
+    primaryActionLabel: 'Import your first statement'
+  },
+  deviceProfiles: []
+}
+
+test('manages local categories and rules from the dedicated workspace', async ({ page }) => {
+  await page.addInitScript(({ appState }) => {
+    window.localStorage.setItem('walnut.mock.app-state', JSON.stringify(appState))
+    window.localStorage.setItem('walnut.mock.security-events', '[]')
+    window.localStorage.setItem('walnut.mock.categories', '[]')
+    window.localStorage.setItem('walnut.mock.rules', '[]')
+  }, { appState: dashboardState })
+
+  await page.goto('/')
+
+  await page.getByRole('button', { name: 'Open categories and rules workspace' }).click()
+  await expect(page.getByRole('heading', { name: 'Categories & Rules' })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Add category' }).click()
+  await expect(page.getByRole('heading', { name: 'Create a user category' })).toBeVisible()
+  await page.getByLabel('Name').fill('Fuel')
+  await page.getByRole('button', { name: 'Create category' }).click()
+  await expect(page.locator('strong').filter({ hasText: 'Fuel' }).first()).toBeVisible()
+
+  await page.getByRole('button', { name: 'Add rule' }).click()
+  await expect(page.getByRole('heading', { name: 'Create reusable rule' })).toBeVisible()
+  await page.getByLabel('Rule name').fill('Fuel rule')
+  await page.getByLabel('Description keywords').fill('fuel, petrol')
+  await page.locator('label').filter({ hasText: 'Transaction type' }).locator('select').first().selectOption('expense')
+  await page.getByLabel('Assign category').selectOption({ label: 'Fuel' })
+  await page.getByRole('button', { name: 'Save rule' }).click()
+
+  await expect(page.getByText('Fuel rule')).toBeVisible()
+  await expect(page.getByText('types: expense')).toBeVisible()
+})

--- a/tests/unit/categories-rules-screen.test.tsx
+++ b/tests/unit/categories-rules-screen.test.tsx
@@ -1,0 +1,225 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import App from '../../src/renderer/App'
+import type { WalnutApi } from '../../src/shared/contracts/app-state'
+
+const dashboardState = {
+  currentView: 'dashboard' as const,
+  onboarding: {
+    currentStep: 'finish' as const,
+    completedSteps: ['welcome', 'household-profile', 'pin-setup', 'recovery-key', 'account-profile', 'finish'],
+    recoveryConfirmed: true,
+    recoverySavedToDevice: true,
+    profile: {
+      householdName: 'Walnut Home',
+      ownerName: 'Bit'
+    }
+  },
+  security: {
+    failedAttempts: 0,
+    isLocked: false
+  },
+  dashboard: {
+    heading: 'Ready for your first import',
+    body: 'Add your first ICICI statement to create the account timeline and unlock dashboard insights.',
+    primaryActionLabel: 'Import your first statement'
+  },
+  deviceProfiles: []
+}
+
+const categories = [
+  {
+    id: 'cat:income',
+    name: 'Income',
+    kind: 'system' as const,
+    path: ['Income'],
+    isActive: true,
+    isIncomeCategory: true,
+    sortOrder: 10,
+    counts: { directTransactionCount: 0, totalTransactionCount: 2 },
+    children: [
+      {
+        id: 'cat:income-salary',
+        name: 'Salary',
+        kind: 'system' as const,
+        parentId: 'cat:income',
+        path: ['Income', 'Salary'],
+        isActive: true,
+        isIncomeCategory: true,
+        sortOrder: 11,
+        counts: { directTransactionCount: 2, totalTransactionCount: 2 },
+        children: []
+      }
+    ]
+  },
+  {
+    id: 'cat:dining-out',
+    name: 'Dining Out',
+    kind: 'user' as const,
+    path: ['Dining Out'],
+    isActive: true,
+    isIncomeCategory: false,
+    sortOrder: 20,
+    counts: { directTransactionCount: 3, totalTransactionCount: 3 },
+    children: []
+  }
+]
+
+const rules = [
+  {
+    id: 'rule:dining',
+    name: 'Dining rule',
+    kind: 'user' as const,
+    isEnabled: true,
+    condition: {
+      descriptionContains: ['burger'],
+      transactionTypes: ['expense' as const],
+      tags: [],
+      directions: ['debit' as const]
+    },
+    action: {
+      categoryId: 'cat:dining-out',
+      type: 'expense' as const,
+      appendTags: ['restaurant']
+    },
+    specificityScore: 8,
+    affectedTransactionCount: 3,
+    updatedAt: '2026-03-28T18:00:00.000Z'
+  }
+]
+
+const createWalnutApi = () => {
+  const api = {
+    loadAppState: vi.fn().mockResolvedValue(dashboardState),
+    saveOnboardingProgress: vi.fn(),
+    completeOnboarding: vi.fn(),
+    startNewProfileSetup: vi.fn(),
+    switchDeviceProfile: vi.fn(),
+    lockNow: vi.fn(),
+    unlockWithPin: vi.fn(),
+    beginRecoveryReset: vi.fn(),
+    saveAccountProfile: vi.fn(),
+    copyRecoveryKeyAcknowledged: vi.fn(),
+    downloadRecoveryKeyAcknowledged: vi.fn(),
+    getSecurityEvents: vi.fn().mockResolvedValue([]),
+    stageImportFiles: vi.fn(),
+    chooseImportSheet: vi.fn(),
+    removeStagedFile: vi.fn(),
+    commitImportBatch: vi.fn(),
+    inspectPriorImportBatch: vi.fn(),
+    listImportHistory: vi.fn().mockResolvedValue([]),
+    getImportBatchDetail: vi.fn(),
+    getReviewQueue: vi.fn().mockResolvedValue([]),
+    resolveReviewItems: vi.fn(),
+    restoreReviewItems: vi.fn(),
+    listTransactions: vi.fn().mockResolvedValue([]),
+    getTransactionDetail: vi.fn(),
+    updateTransaction: vi.fn(),
+    listCategories: vi.fn().mockResolvedValue(categories),
+    createCategory: vi.fn().mockResolvedValue(categories),
+    updateCategory: vi.fn().mockResolvedValue(categories),
+    mergeCategory: vi.fn().mockResolvedValue(categories),
+    deleteCategory: vi.fn().mockResolvedValue(categories),
+    listRules: vi.fn().mockResolvedValue(rules),
+    createRule: vi.fn().mockResolvedValue(rules),
+    updateRule: vi.fn().mockResolvedValue(rules),
+    toggleRule: vi.fn().mockResolvedValue(rules),
+    deleteRule: vi.fn().mockResolvedValue(rules),
+    testRule: vi.fn().mockResolvedValue({
+      matchCount: 3,
+      samples: [
+        {
+          transactionId: 'txn-1',
+          transactionDateRaw: '2024-01-01',
+          description: 'Burger King NSP',
+          signedAmountMinor: -74000,
+          currentType: 'expense' as const,
+          nextType: 'expense' as const,
+          currentCategoryPath: undefined,
+          nextCategoryPath: ['Dining Out'],
+          tags: ['restaurant']
+        }
+      ]
+    }),
+    previewRuleApplyToExisting: vi.fn().mockResolvedValue({
+      matchCount: 3,
+      samples: [
+        {
+          transactionId: 'txn-1',
+          transactionDateRaw: '2024-01-01',
+          description: 'Burger King NSP',
+          signedAmountMinor: -74000,
+          currentType: 'expense' as const,
+          nextType: 'expense' as const,
+          currentCategoryPath: undefined,
+          nextCategoryPath: ['Dining Out'],
+          tags: ['restaurant']
+        }
+      ]
+    }),
+    applyRuleToExisting: vi.fn().mockResolvedValue(rules),
+    ping: vi.fn().mockResolvedValue('pong')
+  } satisfies Partial<WalnutApi>
+
+  return api as WalnutApi & {
+    createCategory: ReturnType<typeof vi.fn>
+    testRule: ReturnType<typeof vi.fn>
+  }
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+afterEach(() => {
+  window.localStorage.clear()
+  delete (window as typeof window & { walnut?: unknown }).walnut
+})
+
+describe('categories and rules screen', () => {
+  it('renders the dedicated workspace, protected cues, and category management side panel', async () => {
+    const user = userEvent.setup()
+    const walnut = createWalnutApi()
+    window.walnut = walnut
+
+    render(<App />)
+
+    await user.click(await screen.findByRole('button', { name: 'Open categories and rules workspace' }))
+    await screen.findByRole('heading', { name: 'Categories & Rules' })
+
+    expect(screen.getAllByText('Protected').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Dining Out').length).toBeGreaterThan(0)
+    expect(screen.getByText('3 mapped')).toBeVisible()
+    expect(screen.getByText('Dining rule')).toBeVisible()
+    expect(screen.getByText('3 affected transactions')).toBeVisible()
+
+    await user.click(screen.getByRole('button', { name: 'Add category' }))
+    await screen.findByRole('heading', { name: 'Create a user category' })
+    await user.type(screen.getByLabelText('Name'), 'Fuel')
+    await user.click(screen.getByRole('button', { name: 'Create category' }))
+
+    await waitFor(() => expect(walnut.createCategory).toHaveBeenCalled())
+  })
+
+  it('opens the rule editor and preview surface in context', async () => {
+    const user = userEvent.setup()
+    const walnut = createWalnutApi()
+    window.walnut = walnut
+
+    render(<App />)
+
+    await user.click(await screen.findByRole('button', { name: 'Open categories and rules workspace' }))
+    await screen.findByRole('heading', { name: 'Categories & Rules' })
+
+    const ruleRow = screen.getByText('Dining rule').closest('article')
+    expect(ruleRow).not.toBeNull()
+    await user.click(within(ruleRow!).getByRole('button', { name: 'Manage' }))
+    await screen.findByRole('heading', { name: 'Dining rule' })
+    await user.click(screen.getByRole('button', { name: 'Test rule' }))
+
+    await waitFor(() => expect(walnut.testRule).toHaveBeenCalled())
+    expect(await screen.findByRole('heading', { name: 'Review affected transactions' })).toBeVisible()
+    expect(screen.getByText(/matching transactions/)).toBeVisible()
+  })
+})

--- a/tests/unit/categories/category-repository.test.ts
+++ b/tests/unit/categories/category-repository.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import type { NormalizedImportRow, StagedImportFile } from '../../../src/shared/contracts/import'
+import { WalnutRepository } from '../../../src/main/persistence/db'
+
+const createRepository = () => new WalnutRepository(':memory:')
+
+const createStagedFile = (id: string, fileName: string): StagedImportFile => ({
+  id,
+  fileName,
+  fileExtension: 'xlsx',
+  accountLabel: 'ICICI - Household',
+  statementPeriodLabel: 'Jan 2024',
+  status: 'ready'
+})
+
+const createRow = (sourceFileId: string, index: number, overrides: Partial<NormalizedImportRow> = {}): NormalizedImportRow => ({
+  transactionDateRaw: `2024-01-${String(index + 1).padStart(2, '0')}`,
+  rawNarration: `Narration ${index}`,
+  cleanedDescription: `Description ${index}`,
+  debitAmountMinor: 1000 + index,
+  direction: 'debit',
+  sourceFileId,
+  importBatchId: 'batch-categories',
+  ...overrides
+})
+
+describe('category repository', () => {
+  it('seeds the protected system taxonomy with income subcategories', () => {
+    const repository = createRepository()
+
+    const categories = repository.listCategories()
+    const topLevelNames = categories.map((category) => category.name)
+
+    expect(topLevelNames).toEqual([
+      'Food & Dining',
+      'Groceries',
+      'Shopping',
+      'Bills & Utilities',
+      'Rent / Housing',
+      'Transport',
+      'Travel',
+      'Healthcare',
+      'Entertainment',
+      'Education',
+      'Insurance',
+      'Taxes & Fees',
+      'Cash / ATM',
+      'Transfers',
+      'Credit Card Payment',
+      'Income',
+      'Refunds / Reimbursements',
+      'Investments / Savings',
+      'Uncategorized'
+    ])
+
+    const income = categories.find((category) => category.name === 'Income')
+    expect(income).toBeDefined()
+    expect(income?.kind).toBe('system')
+    expect(income?.children.map((child) => child.name)).toEqual([
+      'Salary',
+      'Business Income',
+      'Interest',
+      'Refund / Reimbursement Income',
+      'Investment Income',
+      'Other Income'
+    ])
+
+    repository.close()
+  })
+
+  it('protects system categories and safely manages user categories including merge migration', () => {
+    const repository = createRepository()
+    const income = repository.listCategories().find((category) => category.name === 'Income')
+    const transfers = repository.listCategories().find((category) => category.name === 'Transfers')
+
+    expect(() =>
+      repository.deleteCategory({
+        categoryId: income!.id
+      })
+    ).toThrow(/system category/i)
+
+    const created = repository.createCategory({
+      name: 'Eating Out',
+      parentId: undefined
+    })
+    const eatingOut = created.find((category) => category.name === 'Eating Out')
+    expect(eatingOut).toBeDefined()
+    expect(eatingOut?.kind).toBe('user')
+
+    const moved = repository.updateCategory({
+      categoryId: eatingOut!.id,
+      parentId: transfers!.id
+    })
+    const movedCategory = moved
+      .flatMap((category) => [category, ...category.children])
+      .find((category) => category.id === eatingOut!.id)
+    expect(movedCategory?.path).toEqual(['Transfers', 'Eating Out'])
+
+    repository.persistImportAttempt({
+      attemptId: 'attempt-categories',
+      batchId: 'batch-categories',
+      batchLabel: 'Categories batch',
+      status: 'imported',
+      importedAt: '2026-03-28T12:00:00.000Z',
+      accountLabel: 'ICICI - Household',
+      importedFiles: [createStagedFile('file-categories', 'categories.xlsx')],
+      rejectedFiles: [],
+      duplicateBlockedFiles: [],
+      acceptedFiles: [
+        {
+          stagedFile: createStagedFile('file-categories', 'categories.xlsx'),
+          fileFingerprint: 'fingerprint-categories',
+          transactionSignatures: ['sig-category'],
+          rows: [
+            createRow('file-categories', 0, {
+              cleanedDescription: 'Manual category seed',
+              rawNarration: 'Manual category seed',
+              debitAmountMinor: 24000
+            })
+          ]
+        }
+      ],
+      reviewItems: [],
+      lazyAccountCreated: false
+    })
+
+    const transaction = repository.listTransactions()[0]
+    repository.updateTransaction({
+      transactionId: transaction.id,
+      categoryId: eatingOut!.id
+    })
+
+    const merged = repository.createCategory({
+      name: 'Dining Out'
+    })
+    const diningOut = merged.find((category) => category.name === 'Dining Out')
+    expect(diningOut).toBeDefined()
+
+    repository.mergeCategory({
+      sourceCategoryId: eatingOut!.id,
+      targetCategoryId: diningOut!.id
+    })
+
+    const detail = repository.getTransactionDetail({ transactionId: transaction.id })
+    expect(detail.categoryId).toBe(diningOut!.id)
+    expect(detail.categoryPath).toEqual(['Dining Out'])
+
+    repository.close()
+  })
+})

--- a/tests/unit/categories/rule-engine.test.ts
+++ b/tests/unit/categories/rule-engine.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+import type { CreateCategorizationRuleInput } from '../../../src/shared/contracts/categories'
+import type { NormalizedImportRow, StagedImportFile } from '../../../src/shared/contracts/import'
+import { WalnutRepository } from '../../../src/main/persistence/db'
+
+const createRepository = () => new WalnutRepository(':memory:')
+
+const createStagedFile = (id: string, fileName: string): StagedImportFile => ({
+  id,
+  fileName,
+  fileExtension: 'xlsx',
+  accountLabel: 'ICICI - Household',
+  statementPeriodLabel: 'Jan 2024',
+  status: 'ready'
+})
+
+const createRow = (sourceFileId: string, index: number, overrides: Partial<NormalizedImportRow> = {}): NormalizedImportRow => ({
+  transactionDateRaw: `2024-01-${String(index + 1).padStart(2, '0')}`,
+  rawNarration: `Narration ${index}`,
+  cleanedDescription: `Description ${index}`,
+  debitAmountMinor: 1000 + index,
+  direction: 'debit',
+  sourceFileId,
+  importBatchId: 'batch-rules',
+  ...overrides
+})
+
+describe('rule engine', () => {
+  it('seeds starter system rules with the supported condition and action surface', () => {
+    const repository = createRepository()
+
+    const rules = repository.listRules()
+    expect(rules.length).toBeGreaterThan(0)
+    expect(rules.some((rule) => rule.kind === 'system')).toBe(true)
+
+    for (const rule of rules) {
+      expect(Array.isArray(rule.condition.descriptionContains)).toBe(true)
+      expect(Array.isArray(rule.condition.transactionTypes)).toBe(true)
+      expect(Array.isArray(rule.condition.tags)).toBe(true)
+      expect(Array.isArray(rule.condition.directions)).toBe(true)
+      expect(Array.isArray(rule.action.appendTags)).toBe(true)
+    }
+
+    repository.close()
+  })
+
+  it('prefers the most specific enabled user rule and supports preview-first application', () => {
+    const repository = createRepository()
+    const dining = repository.createCategory({ name: 'Dining Out' }).find((category) => category.name === 'Dining Out')
+    const groceries = repository.listCategories().find((category) => category.name === 'Groceries')
+
+    repository.persistImportAttempt({
+      attemptId: 'attempt-rules',
+      batchId: 'batch-rules',
+      batchLabel: 'Rules batch',
+      status: 'imported',
+      importedAt: '2026-03-28T12:00:00.000Z',
+      accountLabel: 'ICICI - Household',
+      importedFiles: [createStagedFile('file-rules', 'rules.xlsx')],
+      rejectedFiles: [],
+      duplicateBlockedFiles: [],
+      acceptedFiles: [
+        {
+          stagedFile: createStagedFile('file-rules', 'rules.xlsx'),
+          fileFingerprint: 'fingerprint-rules',
+          transactionSignatures: ['sig-rules-1', 'sig-rules-2'],
+          rows: [
+            createRow('file-rules', 0, {
+              cleanedDescription: 'Burger King NSP',
+              rawNarration: 'Burger King NSP',
+              debitAmountMinor: 74000,
+              tags: ['food']
+            }),
+            createRow('file-rules', 1, {
+              cleanedDescription: 'DMART groceries',
+              rawNarration: 'DMART groceries',
+              debitAmountMinor: 120000,
+              tags: ['home']
+            })
+          ]
+        }
+      ],
+      reviewItems: [],
+      lazyAccountCreated: false
+    })
+
+    const genericFoodRule: CreateCategorizationRuleInput = {
+      name: 'Generic food',
+      condition: {
+        descriptionContains: ['king'],
+        transactionTypes: ['expense'],
+        tags: [],
+        directions: ['debit']
+      },
+      action: {
+        categoryId: groceries!.id,
+        appendTags: ['meal']
+      }
+    }
+
+    const specificFoodRule: CreateCategorizationRuleInput = {
+      name: 'Burger King dining',
+      condition: {
+        descriptionContains: ['burger', 'king'],
+        amountMinMinor: 50000,
+        amountMaxMinor: 100000,
+        transactionTypes: ['expense'],
+        tags: [],
+        directions: ['debit']
+      },
+      action: {
+        categoryId: dining!.id,
+        type: 'expense',
+        appendTags: ['restaurant']
+      }
+    }
+
+    repository.createRule(genericFoodRule)
+    const createdRules = repository.createRule(specificFoodRule)
+    const targetRule = createdRules.find((rule) => rule.name === 'Burger King dining')
+    expect(targetRule).toBeDefined()
+
+    const preview = repository.previewRuleApplyToExisting({ ruleId: targetRule!.id })
+    expect(preview.matchCount).toBe(1)
+    expect(preview.samples[0]).toMatchObject({
+      description: 'Burger King NSP',
+      nextCategoryPath: ['Dining Out'],
+      nextType: 'expense'
+    })
+
+    repository.applyRuleToExisting({ ruleId: targetRule!.id })
+
+    const burger = repository.listTransactions({ search: 'burger' })[0]
+    expect(burger.categoryId).toBe(dining!.id)
+    expect(burger.categoryPath).toEqual(['Dining Out'])
+    expect(burger.tags).toContain('restaurant')
+
+    repository.close()
+  })
+})

--- a/tests/unit/transaction-ledger.test.tsx
+++ b/tests/unit/transaction-ledger.test.tsx
@@ -43,6 +43,8 @@ const ledgerRows: TransactionLedgerRow[] = [
     runningBalanceMinor: 4500000,
     normalizedType: 'income',
     tags: ['salary'],
+    categoryId: undefined,
+    categoryPath: undefined,
     reviewState: 'clean',
     reference: 'SAL-20'
   },
@@ -59,6 +61,8 @@ const ledgerRows: TransactionLedgerRow[] = [
     runningBalanceMinor: 175000,
     normalizedType: 'expense',
     tags: ['coffee'],
+    categoryId: undefined,
+    categoryPath: undefined,
     reviewState: 'pending-review',
     reference: 'COF-18'
   }
@@ -77,6 +81,8 @@ const transactionDetail: TransactionDetail = {
   description: 'Coffee shop',
   signedAmountMinor: -24000,
   normalizedType: 'expense',
+  categoryId: undefined,
+  categoryPath: undefined,
   tags: ['coffee'],
   reference: 'COF-18',
   reviewState: 'pending-review',
@@ -108,7 +114,21 @@ const createWalnutApi = () => {
             fromType: transactionDetail.normalizedType,
             toType: input.normalizedType,
             title: 'Create a rule from this type change later',
-            description: 'Walnut can use this correction as a suggestion when reusable rules are introduced.'
+            description: 'Walnut can use this correction as a suggestion when reusable rules are introduced.',
+            draft: {
+              name: 'Coffee shop rule',
+              condition: {
+                descriptionContains: ['coffee', 'shop'],
+                transactionTypes: [transactionDetail.normalizedType],
+                tags: transactionDetail.tags,
+                directions: [transactionDetail.direction]
+              },
+              action: {
+                categoryId: transactionDetail.categoryId,
+                type: input.normalizedType,
+                appendTags: transactionDetail.tags
+              }
+            }
           }
         : undefined
   }))
@@ -139,6 +159,19 @@ const createWalnutApi = () => {
     listTransactions,
     getTransactionDetail,
     updateTransaction,
+    listCategories: vi.fn().mockResolvedValue([]),
+    createCategory: vi.fn().mockResolvedValue([]),
+    updateCategory: vi.fn().mockResolvedValue([]),
+    mergeCategory: vi.fn().mockResolvedValue([]),
+    deleteCategory: vi.fn().mockResolvedValue([]),
+    listRules: vi.fn().mockResolvedValue([]),
+    createRule: vi.fn().mockResolvedValue([]),
+    updateRule: vi.fn().mockResolvedValue([]),
+    toggleRule: vi.fn().mockResolvedValue([]),
+    deleteRule: vi.fn().mockResolvedValue([]),
+    testRule: vi.fn().mockResolvedValue({ matchCount: 0, samples: [] }),
+    previewRuleApplyToExisting: vi.fn().mockResolvedValue({ matchCount: 0, samples: [] }),
+    applyRuleToExisting: vi.fn().mockResolvedValue([]),
     ping: vi.fn().mockResolvedValue('pong')
   } satisfies Partial<WalnutApi>
 
@@ -228,5 +261,5 @@ describe('transaction ledger', () => {
     )
 
     expect(await screen.findByText('Create a rule from this type change later')).toBeVisible()
-  })
+  }, 15000)
 })

--- a/tests/unit/transactions/rule-suggestion.test.tsx
+++ b/tests/unit/transactions/rule-suggestion.test.tsx
@@ -1,0 +1,192 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import App from '../../../src/renderer/App'
+import type { WalnutApi } from '../../../src/shared/contracts/app-state'
+import type { TransactionDetail, TransactionLedgerRow } from '../../../src/shared/contracts/transactions'
+
+const dashboardState = {
+  currentView: 'dashboard' as const,
+  onboarding: {
+    currentStep: 'finish' as const,
+    completedSteps: ['welcome', 'household-profile', 'pin-setup', 'recovery-key', 'account-profile', 'finish'],
+    recoveryConfirmed: true,
+    recoverySavedToDevice: true,
+    profile: {
+      householdName: 'Walnut Home',
+      ownerName: 'Bit'
+    }
+  },
+  security: {
+    failedAttempts: 0,
+    isLocked: false
+  },
+  dashboard: {
+    heading: 'Ready for your first import',
+    body: 'Add your first ICICI statement to create the account timeline and unlock dashboard insights.',
+    primaryActionLabel: 'Import your first statement'
+  },
+  deviceProfiles: []
+}
+
+const ledgerRows: TransactionLedgerRow[] = [
+  {
+    id: 'txn-1',
+    importBatchId: 'batch-1',
+    sourceFileId: 'file-1',
+    transactionDateRaw: '2024-01-18',
+    transactionDateSortable: '2024-01-18',
+    description: 'Coffee shop',
+    signedAmountMinor: -24000,
+    debitAmountMinor: 24000,
+    creditAmountMinor: null,
+    runningBalanceMinor: 175000,
+    normalizedType: 'expense',
+    tags: ['coffee'],
+    categoryId: 'cat:food-dining',
+    categoryPath: ['Food & Dining'],
+    category: 'Food & Dining',
+    reviewState: 'clean',
+    reference: 'COF-18'
+  }
+]
+
+const transactionDetail: TransactionDetail = {
+  id: 'txn-1',
+  importBatchId: 'batch-1',
+  sourceFileId: 'file-1',
+  batchLabel: 'January batch',
+  sourceFileName: 'january.xlsx',
+  importedAt: '2026-03-28T09:00:00.000Z',
+  transactionDateRaw: '2024-01-18',
+  transactionDateSortable: '2024-01-18',
+  rawNarration: 'Coffee shop',
+  description: 'Coffee shop',
+  signedAmountMinor: -24000,
+  normalizedType: 'expense',
+  categoryId: 'cat:food-dining',
+  categoryPath: ['Food & Dining'],
+  category: 'Food & Dining',
+  tags: ['coffee'],
+  reference: 'COF-18',
+  reviewState: 'clean',
+  reviewStateOverride: null,
+  runningBalanceMinor: 175000,
+  direction: 'debit'
+}
+
+const createWalnutApi = () => {
+  const api = {
+    loadAppState: vi.fn().mockResolvedValue(dashboardState),
+    saveOnboardingProgress: vi.fn(),
+    completeOnboarding: vi.fn(),
+    startNewProfileSetup: vi.fn(),
+    switchDeviceProfile: vi.fn(),
+    lockNow: vi.fn(),
+    unlockWithPin: vi.fn(),
+    beginRecoveryReset: vi.fn(),
+    saveAccountProfile: vi.fn(),
+    copyRecoveryKeyAcknowledged: vi.fn(),
+    downloadRecoveryKeyAcknowledged: vi.fn(),
+    getSecurityEvents: vi.fn().mockResolvedValue([]),
+    stageImportFiles: vi.fn(),
+    chooseImportSheet: vi.fn(),
+    removeStagedFile: vi.fn(),
+    commitImportBatch: vi.fn(),
+    inspectPriorImportBatch: vi.fn(),
+    listImportHistory: vi.fn().mockResolvedValue([]),
+    getImportBatchDetail: vi.fn(),
+    getReviewQueue: vi.fn().mockResolvedValue([]),
+    resolveReviewItems: vi.fn(),
+    restoreReviewItems: vi.fn(),
+    listTransactions: vi.fn().mockResolvedValue(ledgerRows),
+    getTransactionDetail: vi.fn().mockResolvedValue(transactionDetail),
+    updateTransaction: vi.fn().mockResolvedValue({
+      detail: { ...transactionDetail, normalizedType: 'transfer' as const },
+      ruleSuggestion: {
+        field: 'type' as const,
+        fromType: 'expense' as const,
+        toType: 'transfer' as const,
+        title: 'Create a rule from this type change later',
+        description: 'Walnut can use this correction as a reusable rule suggestion.',
+        draft: {
+          name: 'Coffee shop rule',
+          condition: {
+            descriptionContains: ['coffee', 'shop'],
+            transactionTypes: ['expense' as const],
+            tags: ['coffee'],
+            directions: ['debit' as const]
+          },
+          action: {
+            categoryId: 'cat:food-dining',
+            type: 'transfer' as const,
+            appendTags: ['coffee']
+          }
+        }
+      }
+    }),
+    listCategories: vi.fn().mockResolvedValue([
+      {
+        id: 'cat:food-dining',
+        name: 'Food & Dining',
+        kind: 'system' as const,
+        path: ['Food & Dining'],
+        isActive: true,
+        isIncomeCategory: false,
+        sortOrder: 10,
+        counts: { directTransactionCount: 1, totalTransactionCount: 1 },
+        children: []
+      }
+    ]),
+    createCategory: vi.fn().mockResolvedValue([]),
+    updateCategory: vi.fn().mockResolvedValue([]),
+    mergeCategory: vi.fn().mockResolvedValue([]),
+    deleteCategory: vi.fn().mockResolvedValue([]),
+    listRules: vi.fn().mockResolvedValue([]),
+    createRule: vi.fn().mockResolvedValue([]),
+    updateRule: vi.fn().mockResolvedValue([]),
+    toggleRule: vi.fn().mockResolvedValue([]),
+    deleteRule: vi.fn().mockResolvedValue([]),
+    testRule: vi.fn().mockResolvedValue({ matchCount: 0, samples: [] }),
+    previewRuleApplyToExisting: vi.fn().mockResolvedValue({ matchCount: 0, samples: [] }),
+    applyRuleToExisting: vi.fn().mockResolvedValue([]),
+    ping: vi.fn().mockResolvedValue('pong')
+  } satisfies Partial<WalnutApi>
+
+  return api as WalnutApi
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+afterEach(() => {
+  window.localStorage.clear()
+  delete (window as typeof window & { walnut?: unknown }).walnut
+})
+
+describe('transaction rule suggestion handoff', () => {
+  it('opens the categories and rules workspace with a prefilled rule draft after a transaction type correction', async () => {
+    const user = userEvent.setup()
+    window.walnut = createWalnutApi()
+
+    render(<App />)
+
+    await user.click(await screen.findByRole('button', { name: 'Open transactions workspace' }))
+    await screen.findByRole('heading', { name: 'Transactions' })
+    await screen.findByText('Coffee shop')
+
+    await user.click(await screen.findByRole('button', { name: 'Edit transaction Coffee shop' }))
+    await screen.findByRole('heading', { name: 'Coffee shop' })
+    await user.selectOptions(screen.getByLabelText('Type'), 'transfer')
+    await user.click(screen.getByRole('button', { name: 'Save transaction' }))
+
+    expect(await screen.findByText('Create a rule from this type change later')).toBeVisible()
+    await user.click(screen.getByRole('button', { name: 'Create reusable rule' }))
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Categories & Rules' })).toBeVisible())
+    expect(await screen.findByRole('heading', { name: 'Create reusable rule' })).toBeVisible()
+    expect(screen.getByDisplayValue('Coffee shop rule')).toBeVisible()
+    expect(screen.getByDisplayValue('coffee, shop')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
- add the protected starter taxonomy and income subcategories with safe user-category management
- implement deterministic reusable categorization rules with preview-first apply flows
- add the Categories & Rules workspace and ledger rule-suggestion handoff

## Verification
- npm run test:unit
- npm run test:e2e
- npm run build

## Tracking
- Epic: #5
- Stories: #35, #36, #37, #39